### PR TITLE
imap-hibernate: send connect/disconnect events to anvil

### DIFF
--- a/src/imap-hibernate/imap-client.h
+++ b/src/imap-hibernate/imap-client.h
@@ -22,6 +22,7 @@ struct imap_client_state {
 	unsigned int imap_idle_notify_interval;
 	bool idle_cmd;
 	bool have_notify_fd;
+	bool anvil_sent;
 };
 
 struct imap_client *


### PR DESCRIPTION
This makes `doveadm who` and `mail_max_userip_connections` work with hibernated connections.