### PR TITLE
fts-squat: fix Corrupted squat uidlist bug

### DIFF
--- a/src/plugins/fts-squat/fts-backend-squat.c
+++ b/src/plugins/fts-squat/fts-backend-squat.c
@@ -147,9 +147,7 @@ fts_backend_squat_set_box(struct squat_fts_backend *backend,
 	if (backend->full_len != 0)
 		squat_trie_set_full_len(backend->trie, backend->full_len);
 	backend->box = box;
-	ret = squat_trie_open(backend->trie);
-	if (ret < 0)
-		return -1;
+	return squat_trie_open(backend->trie);
 }
 
 static int

--- a/src/plugins/fts-squat/squat-trie.c
+++ b/src/plugins/fts-squat/squat-trie.c
@@ -235,7 +235,7 @@ static int squat_trie_open_fd(struct squat_trie *trie)
 	return 0;
 }
 
-static int squat_trie_open(struct squat_trie *trie)
+int squat_trie_open(struct squat_trie *trie)
 {
 	squat_trie_close(trie);
 

--- a/src/plugins/fts-squat/squat-trie.h
+++ b/src/plugins/fts-squat/squat-trie.h
@@ -26,6 +26,7 @@ void squat_trie_deinit(struct squat_trie **trie);
 void squat_trie_set_partial_len(struct squat_trie *trie, unsigned int len);
 void squat_trie_set_full_len(struct squat_trie *trie, unsigned int len);
 
+int squat_trie_open(struct squat_trie *trie);
 int squat_trie_refresh(struct squat_trie *trie);
 
 int squat_trie_build_init(struct squat_trie *trie,

--- a/src/plugins/fts-squat/squat-uidlist.c
+++ b/src/plugins/fts-squat/squat-uidlist.c
@@ -371,7 +371,7 @@ static int squat_uidlist_map_header(struct squat_uidlist *uidlist)
 	}
 	if (uidlist->hdr.indexid != uidlist->trie->hdr.indexid) {
 		/* see if trie was recreated */
-		(void)squat_trie_refresh(uidlist->trie);
+		(void)squat_trie_open(uidlist->trie);
 	}
 	if (uidlist->hdr.indexid != uidlist->trie->hdr.indexid) {
 		squat_uidlist_set_corrupted(uidlist, "wrong indexid");


### PR DESCRIPTION
Hello,

I have experienced the "Corrupted squat uidlist" bug described in these two threads:

http://dovecot.org/list/dovecot/2012-April/135162.html
http://dovecot.org/list/dovecot/2016-January/102864.html

and I have tested a patch based on the explanation in the second thread. This has been working flawlessly for approximately a month. I'd really like to see this merged so I don't have to repatch it every time. 
