### PR TITLE
lmtp: Use port 24 if no port has been provided

### DIFF
--- a/src/lmtp/commands.c
+++ b/src/lmtp/commands.c
@@ -252,6 +252,8 @@ client_proxy_rcpt_parse_fields(struct lmtp_proxy_rcpt_settings *set,
 		} else if (strcmp(key, "protocol") == 0) {
 			if (strcmp(value, "lmtp") == 0)
 				set->protocol = LMTP_CLIENT_PROTOCOL_LMTP;
+				if (!port_set)
+					set->port = 24;
 			else if (strcmp(value, "smtp") == 0) {
 				set->protocol = LMTP_CLIENT_PROTOCOL_SMTP;
 				if (!port_set)


### PR DESCRIPTION
This allows using the LMTP, IMAP and POP3 proxy on the same
Dovecot installation without the userdb providing the port
to connect to.

TCP port 24 is registered at IANA as: "any private mail system"

LMTP being the Local Mail Transfer Protocol classifies as a private
mail system and thus justifies the usage of port 24.

Prior to this patch the LTMP client would connect to TCP port 0 by
default if the userdb did not provide a port to connect to.