### PR TITLE
quota_clone plugin: quota_clone_mail_user_created warned without debug

### DIFF
--- a/src/plugins/quota-clone/quota-clone-plugin.c
+++ b/src/plugins/quota-clone/quota-clone-plugin.c
@@ -164,7 +164,9 @@ static void quota_clone_mail_user_created(struct mail_user *user)
 
 	uri = mail_user_plugin_getenv(user, "quota_clone_dict");
 	if (uri == NULL || uri[0] == '\0') {
-		i_error("The quota_clone_dict setting is missing from configuration");
+		if (user->mail_debug) {
+			i_debug("The quota_clone_dict setting is missing from configuration");
+		}
 		return;
 	}
 


### PR DESCRIPTION
"The quota_clone_dict setting is missing from configuration" warning
would be thrown when debug mode was not enabled.  This warning
happens under normal circumstances when prefix="" namespace is not
defined (usually when set to INBOX.)

See http://dovecot.org/list/dovecot-cvs/2012-October/021981.html for
more details on the automagic prefix="" namespace.

This change suppresses the spurious warning.