### PR TITLE
check for NULL

### DIFF
--- a/src/lib-storage/mail-namespace.c
+++ b/src/lib-storage/mail-namespace.c
@@ -735,7 +735,7 @@ mail_namespace_find_unsubscribable(struct mail_namespace *namespaces,
 struct mail_namespace *
 mail_namespace_find_inbox(struct mail_namespace *namespaces)
 {
-	while ((namespaces->flags & NAMESPACE_FLAG_INBOX_USER) == 0)
+	while (namespaces!=NULL && (namespaces->flags & NAMESPACE_FLAG_INBOX_USER) == 0)
 		namespaces = namespaces->next;
 	return namespaces;
 }


### PR DESCRIPTION
managesieve was complaining about not knowing virtual driver for virtual namespace, which meant process kept dying (due to error in lib-storage).  as a quick kludge I set the following flag in main.c for managesieve.
 MAIL_STORAGE_SERVICE_FLAG_NO_NAMESPACES

However that leads to mail-namespace.c segfaulting due to deref nullptr, and I fix this here.  I don't understand code base well enough for proper fix, but I guess this should not do any harm.