### PR TITLE
Additional systemd service hardening

### DIFF
--- a/dovecot.service.in
+++ b/dovecot.service.in
@@ -30,8 +30,10 @@ ExecReload=@bindir@/doveadm reload
 ExecStop=@bindir@/doveadm stop
 PrivateTmp=true
 NonBlocking=yes
-# Enable this if your systemd is new enough to support it:
-#ProtectSystem=full
+ProtectSystem=full
+NoNewPrivileges=true
+PrivateDevices=true
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_IPC_LOCK CAP_KILL CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add ProtectSystem=full, NoNewPrivileges=true, PrivateDevices=true, and a restricted CapabilityBoundingSet.

There's no reason to comment out any of these options - according to the systemd documentation at https://www.freedesktop.org/software/systemd/man/systemd.unit.html :
> If systemd encounters an unknown option, it will write a warning log message but continue loading the unit.

So it's fine to leave in options that older versions may not understand - they'll simply be ignored.