### PR TITLE
Fix data stack memory leak in FTS storage layer

### DIFF
--- a/src/plugins/fts/fts-storage.c
+++ b/src/plugins/fts/fts-storage.c
@@ -645,8 +645,11 @@ fts_transaction_commit(struct mailbox_transaction_context *t,
 	if (ret < 0)
 		return -1;
 
-	if (autoindex)
-		fts_queue_index(box);
+	if (autoindex) {
+		T_BEGIN {
+			fts_queue_index(box);
+		} T_END;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
As `fts_transaction_commit' is a top-level plug-in hook memory allocated
on the data stack must be freed.

Credits to Matthias Schaff <matthias.schaff@inovex.de>