### PR TITLE
Fix segfault when preparing BODYSTRUCTURE response

### DIFF
--- a/src/lib-imap/imap-bodystructure.c
+++ b/src/lib-imap/imap-bodystructure.c
@@ -291,7 +291,7 @@ part_write_bodystructure_data_common(struct message_part_body_data *data,
 				     string_t *str)
 {
 	str_append_c(str, ' ');
-	if (data->content_disposition == NULL)
+	if (!data || data->content_disposition == NULL)
 		str_append(str, "NIL");
 	else {
 		str_append_c(str, '(');
@@ -309,7 +309,7 @@ part_write_bodystructure_data_common(struct message_part_body_data *data,
 	}
 
 	str_append_c(str, ' ');
-	if (data->content_language == NULL)
+	if (!data || data->content_language == NULL)
 		str_append(str, "NIL");
 	else {
 		str_append_c(str, '(');
@@ -318,7 +318,11 @@ part_write_bodystructure_data_common(struct message_part_body_data *data,
 	}
 
 	str_append_c(str, ' ');
-	str_append(str, NVL(data->content_location, "NIL"));
+	if (!data || data->content_location == NULL)
+		str_append(str, "NIL");
+	else {
+		str_append(str, data->content_location);
+	}
 }
 
 static void part_write_body_multipart(const struct message_part *part,
@@ -336,7 +340,7 @@ static void part_write_body_multipart(const struct message_part *part,
 	}
 
 	str_append_c(str, ' ');
-	if (data->content_subtype != NULL)
+	if (data && data->content_subtype != NULL)
 		str_append(str, data->content_subtype);
 	else
 		str_append(str, "\"x-unknown\"");
@@ -346,7 +350,7 @@ static void part_write_body_multipart(const struct message_part *part,
 
 	/* BODYSTRUCTURE data */
 	str_append_c(str, ' ');
-	if (data->content_type_params == NULL)
+	if (!data || data->content_type_params == NULL)
 		str_append(str, "NIL");
 	else {
 		str_append_c(str, '(');


### PR DESCRIPTION
Apparently the `context' member of a `message_part_body_data' item may become NULL supposedly when fetching BODYSTRUCTURE for mails with broken MIME structure. None of the code here really is prepared for this situation and so this might apply to FETCH BODY responses as well.

Credits to Matthias Schaff <matthias.schaff@inovex.de>