### PR TITLE
Add new config options for fts_solr

### DIFF
--- a/src/plugins/fts-solr/fts-solr-plugin.c
+++ b/src/plugins/fts-solr/fts-solr-plugin.c
@@ -37,6 +37,10 @@ fts_solr_plugin_init_settings(struct mail_user *user,
 		} else if (strcmp(*tmp, "default_ns=") == 0) {
 			set->default_ns_prefix =
 				p_strdup(user->pool, *tmp + 11);
+		} else if (strcmp(*tmp, "limit_mime_hdr") == 0) {
+			set->limit_mime_hdr = TRUE;
+		} else if (strcmp(*tmp, "skip_mime_hdr_fieldname") == 0) {
+			set->skip_mime_hdr_fieldname = TRUE;
 		} else {
 			i_error("fts_solr: Invalid setting: %s", *tmp);
 			return -1;

--- a/src/plugins/fts-solr/fts-solr-plugin.h
+++ b/src/plugins/fts-solr/fts-solr-plugin.h
@@ -12,6 +12,8 @@ struct fts_solr_settings {
 	const char *url, *default_ns_prefix;
 	bool use_libfts;
 	bool debug;
+	bool limit_mime_hdr;
+	bool skip_mime_hdr_fieldname;
 };
 
 struct fts_solr_user {


### PR DESCRIPTION
"From", "To", "Cc", "Bcc", "Subject"

The default for sending header fields to Solr is to send a limited number of headers ("From", "To", "Cc", "Bcc", "Subject") as "field" attributes and all other headers with name and content in the "hdr" field.

```
<field name="From">from@example.com</field>
<field name="To">to@example.com</field>
..
<field name="hdr">
From: from@example.com
To: to@example.com
...
X-Origin-Reference: foo1
X-Origin: foo2
X-Origin-Recipient: foo3
X-Priority: 3
...
X-Foo: content of x-foo
</field>
```

The new config switches to the following:
limit_mime_hdr: limit fields listed in "hdr" field to the same fields as in the standard fields header (From, To, Cc, Bcc, Subject):

```
<field name="From">from@example.com</field>
<field name="To">to@example.com</field>
..
<field name="hdr">
From: from@example.com
To: to@example.com
</field>
skip_mime_hdr_fieldname: Do not put the name of the field in the "hdr" field
<field name="From">from@example.com</field>
<field name="To">to@example.com</field>
..
<field name="hdr">
from@example.com
to@example.com
...
foo1
foo2
foo3
3
...
content of x-foo
</field>
```

if you set both of the config values the result will be something like this:

```
<field name="From">from@example.com</field>
<field name="To">to@example.com</field>
..
<field name="hdr">
from@example.com
to@example.com
...
</field>
```

To use this config values add them to the fts_solr parameter list:

```
plugin {
  # Search
  fts = solr
  fts_solr = break-imap-search url=http://solr.example.com:8080/solr/collection1/ limit_mime_hdr skip_mime_hdr_fieldname
}
```