### PR TITLE
Fix searching multiple mailboxes with fts_solr

### DIFF
--- a/src/plugins/fts-solr/fts-backend-solr.c
+++ b/src/plugins/fts-solr/fts-backend-solr.c
@@ -875,7 +875,7 @@ solr_search_multi(struct fts_backend *_backend, string_t *str,
 	for (i = 0; boxes[i] != NULL; i++) ;
 	search_all_mailboxes = i > SOLR_QUERY_MAX_MAILBOX_COUNT;
 	if (!search_all_mailboxes)
-		str_append(str, "%2B(");
+		str_append(str, "+%2B(");
 	len = str_len(str);
 
 	for (i = 0; boxes[i] != NULL; i++) {


### PR DESCRIPTION
When searching multiple mailboxes with fts_solr, a condition to search these mailboxes is added to the query string. However, this condition has to be separated from the preceding condition by a space (a '+' in this case, as it's encoded); otherwise, Solr considers it to be part of the previous condition, in which case it will fail to parse it properly. Therefore, this patch adds that one missing character so it works again.