### PR TITLE
Set MemoryDenyWriteExecute=true in systemd service

### DIFF
--- a/dovecot.service.in
+++ b/dovecot.service.in
@@ -36,6 +36,7 @@ ProtectSystem=full
 PrivateDevices=true
 NoNewPrivileges=true
 CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_IPC_LOCK CAP_KILL CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_SYS_RESOURCE
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Introduced in systemd 231, MemoryDenyWriteExecute=true causes attempts to create memory mappings that are writable and executable at the same time, or changes to existing memory mappings to become executable, to be prohibited.
