### PR TITLE
add ldap escaping for RFC 2253

### DIFF
--- a/src/auth/db-ldap.h
+++ b/src/auth/db-ldap.h
@@ -199,6 +199,8 @@ void db_ldap_enable_input(struct ldap_connection *conn, bool enable);
 
 const char *ldap_escape(const char *str,
 			const struct auth_request *auth_request);
+const char *ldapdn_escape(const char *str,
+			const struct auth_request *auth_request);
 const char *ldap_get_error(struct ldap_connection *conn);
 
 struct db_ldap_result_iterate_context *

--- a/src/auth/passdb-ldap.c
+++ b/src/auth/passdb-ldap.c
@@ -198,9 +198,8 @@ static void ldap_auth_bind(struct ldap_connection *conn,
 				     auth_request);
 		return;
 	}
-
-	brequest->request.callback = ldap_auth_bind_callback;
-	db_ldap_request(conn, &brequest->request);
+        brequest->request.callback = ldap_auth_bind_callback;
+        db_ldap_request(conn, &brequest->request);
 }
 
 static void
@@ -363,7 +362,7 @@ ldap_verify_plain_auth_bind_userdn(struct auth_request *auth_request,
 	brequest->request.type = LDAP_REQUEST_TYPE_BIND;
 
 	dn = t_str_new(512);
-	auth_request_var_expand(dn, conn->set.auth_bind_userdn, auth_request, ldap_escape);
+	auth_request_var_expand(dn, conn->set.auth_bind_userdn, auth_request, ldapdn_escape);
 
 	brequest->dn = p_strdup(auth_request->pool, str_c(dn));
         ldap_auth_bind(conn, brequest);


### PR DESCRIPTION
fixes a bug for ldap auth_binds for usernames including ldap special chars.

see https://www.mail-archive.com/dovecot@dovecot.org/msg66721.html