### PR TITLE
configure: Improve check for OpenSSL without EC support

### DIFF
--- a/m4/ssl.m4
+++ b/m4/ssl.m4
@@ -38,10 +38,13 @@ AC_DEFUN([DOVECOT_SSL], [
       AC_CHECK_LIB(ssl, SSL_COMP_free_compression_methods, [
         AC_DEFINE(HAVE_SSL_COMP_FREE_COMPRESSION_METHODS,, [Build with SSL_COMP_free_compression_methods() support])
       ],, $SSL_LIBS)
-      AC_CHECK_LIB(ssl, [EVP_PKEY_CTX_new_id],
-        [build_dcrypt_openssl="yes"],
-        AC_MSG_WARN([No ECC support in OpenSSL - not enabling dcrypt]),
-      $SSL_LIBS)
+      AC_CHECK_LIB(ssl, [EVP_PKEY_CTX_new_id], [have_evp_pkey_ctx_new_id="yes"],, $SSL_LIBS)
+      AC_CHECK_LIB(ssl, [EC_KEY_new], [have_ec_key_new="yes"],, $SSL_LIBS)
+      if test "$have_evp_pkey_ctx_new_id" = "yes" && test "$have_ec_key_new" = "yes"; then
+        build_dcrypt_openssl="yes"
+      else
+        AC_MSG_WARN([No ECC support in OpenSSL - not enabling dcrypt])
+      fi
     fi
   fi
   AM_CONDITIONAL(BUILD_OPENSSL, test "$have_openssl" = "yes")


### PR DESCRIPTION
The original test was for EC_KEY_new but some systems had that and not
EVP_PKEY_CTX_new_id, so the test was switched to that function.
However, Fedora releases 12 through 17 have EVP_PKEY_CTX_new_id but
not EC_KEY_new. So we need to test for both functions before enabling
the dcrypt build.