### PR TITLE
configure: Fix build with old OpenSSL without SSL_clear_options

### DIFF
--- a/m4/ssl.m4
+++ b/m4/ssl.m4
@@ -29,6 +29,28 @@ AC_DEFUN([DOVECOT_SSL], [
       AC_DEFINE(HAVE_OPENSSL,, [Build with OpenSSL support])
       have_ssl="yes (OpenSSL)"
   
+      # SSL_clear_options introduced in openssl 0.9.8m but may be backported to
+      # older versions in "enterprise" OS releases; originally implemented as a
+      # macro but as a function in more recent openssl versions
+      AC_CACHE_CHECK([whether SSL_clear_options exists],i_cv_have_ssl_clear_options,[
+        old_LIBS=$LIBS
+        LIBS="$LIBS -lssl"
+        AC_TRY_LINK([
+          #include <openssl/ssl.h>
+        ], [
+          SSL *ssl;
+          long options;
+          SSL_clear_options(ssl, options);
+        ], [
+          i_cv_have_ssl_clear_options=yes
+        ], [
+          i_cv_have_ssl_clear_options=no
+        ])
+        LIBS=$old_LIBS
+      ])
+      if test $i_cv_have_ssl_clear_options = yes; then
+        AC_DEFINE(HAVE_SSL_CLEAR_OPTIONS,, [Define if you have SSL_clear_options])
+      fi
       AC_CHECK_LIB(ssl, SSL_get_current_compression, [
         AC_DEFINE(HAVE_SSL_COMPRESSION,, [Build with OpenSSL compression])
       ],, $SSL_LIBS)

--- a/src/lib-ssl-iostream/iostream-openssl.c
+++ b/src/lib-ssl-iostream/iostream-openssl.c
@@ -163,7 +163,9 @@ openssl_iostream_set(struct ssl_iostream *ssl_io,
 	if (set->prefer_server_ciphers)
 		SSL_set_options(ssl_io->ssl, SSL_OP_CIPHER_SERVER_PREFERENCE);
 	if (set->protocols != NULL) {
+#if defined(HAVE_SSL_CLEAR_OPTIONS)
 		SSL_clear_options(ssl_io->ssl, OPENSSL_ALL_PROTOCOL_OPTIONS);
+#endif
 		SSL_set_options(ssl_io->ssl,
 				openssl_get_protocol_options(set->protocols));
 	}


### PR DESCRIPTION
SSL_clear_options was introduced in OpenSSL 0.9.8m but may be
backported to older versions in "enterprise" OS releases, so a version
check is insufficient here.

It was originally implemented as a macro but is a function in more
recent OpenSSL versions, so a test that works for both cases is needed.