### PR TITLE
configure: Fix some implicit function declarations

### DIFF
--- a/m4/mmap_write.m4
+++ b/m4/mmap_write.m4
@@ -8,6 +8,7 @@ AC_DEFUN([DOVECOT_MMAP_WRITE], [
       #include <unistd.h>
       #include <fcntl.h>
       #include <sys/mman.h>
+      #include <string.h>
       int main() {
         /* return 0 if we're signed */
         int f = open("conftest.mmap", O_RDWR|O_CREAT|O_TRUNC, 0600);

--- a/m4/size_t_signed.m4
+++ b/m4/size_t_signed.m4
@@ -5,6 +5,7 @@ AC_DEFUN([DOVECOT_SIZE_T_SIGNED], [
   AC_CACHE_CHECK([whether size_t is signed],i_cv_signed_size_t,[
     AC_RUN_IFELSE([AC_LANG_SOURCE([[
       #include <sys/types.h>
+      #include <stdlib.h>
       int main() {
         /* return 0 if we're signed */
         exit((size_t)(int)-1 <= 0 ? 0 : 1);

--- a/m4/time_t_signed.m4
+++ b/m4/time_t_signed.m4
@@ -2,6 +2,7 @@ AC_DEFUN([DOVECOT_TIME_T_SIGNED], [
   AC_CACHE_CHECK([whether time_t is signed],i_cv_signed_time_t,[
     AC_RUN_IFELSE([AC_LANG_SOURCE([[
       #include <sys/types.h>
+      #include <stdlib.h>
       int main() {
         /* return 0 if we're signed */
         exit((time_t)(int)-1 <= 0 ? 0 : 1);

--- a/m4/vararg.m4
+++ b/m4/vararg.m4
@@ -2,6 +2,7 @@ AC_DEFUN([DOVECOT_VA_COPY], [
   AC_CACHE_CHECK([for an implementation of va_copy()],lib_cv_va_copy,[
           AC_RUN_IFELSE([AC_LANG_SOURCE([[
           #include <stdarg.h>
+          #include <stdlib.h>
           void f (int i, ...) {
           va_list args1, args2;
           va_start (args1, i);
@@ -20,6 +21,7 @@ AC_DEFUN([DOVECOT_VA_COPY], [
   AC_CACHE_CHECK([for an implementation of __va_copy()],lib_cv___va_copy,[
           AC_RUN_IFELSE([AC_LANG_SOURCE([[
           #include <stdarg.h>
+          #include <stdlib.h>
           void f (int i, ...) {
           va_list args1, args2;
           va_start (args1, i);
@@ -52,6 +54,7 @@ AC_DEFUN([DOVECOT_VA_COPY_BYVAL], [
   AC_CACHE_CHECK([whether va_lists can be copied by value],lib_cv_va_val_copy,[
           AC_RUN_IFELSE([AC_LANG_SOURCE([[
           #include <stdarg.h>
+          #include <stdlib.h>
           void f (int i, ...) {
           va_list args1, args2;
           va_start (args1, i);
@@ -69,6 +72,6 @@ AC_DEFUN([DOVECOT_VA_COPY_BYVAL], [
   ])
   
   if test "x$lib_cv_va_val_copy" = "xno"; then
-    AC_DEFINE(VA_COPY_AS_ARRAY,1, ['va_lists' cannot be copies as values])
+    AC_DEFINE(VA_COPY_AS_ARRAY,1, ['va_lists' cannot be copied as values])
   fi
 ])


### PR DESCRIPTION
Some configure tests fail unexpectedly if the compiler flag
-Werror=implicit-function-declarations is enabled, which can result
in the wrong implementations being used.

This compiler flag is now enabled by default in Fedora Rawhide:
https://fedoraproject.org/wiki/Changes/Fedora26CFlags

<stdlib.h> is needed for exit()
<string.h> is needed for strcpy()