### PR TITLE
openssl: Clear error queue after an incomplete SSL_shutdown

### DIFF
--- a/src/lib-ssl-iostream/iostream-openssl.c
+++ b/src/lib-ssl-iostream/iostream-openssl.c
@@ -299,7 +299,11 @@ static void openssl_iostream_unref(struct ssl_iostream *ssl_io)
 
 static void openssl_iostream_destroy(struct ssl_iostream *ssl_io)
 {
-	(void)SSL_shutdown(ssl_io->ssl);
+	if (SSL_shutdown(ssl_io->ssl) != 1) {
+		/* if bidirectional shutdown fails we need to clear
+		   the error queue */
+		openssl_iostream_clear_errors();
+	}
 	(void)openssl_iostream_more(ssl_io);
 	(void)o_stream_flush(ssl_io->plain_output);
 	/* close the plain i/o streams, because their fd may be closed soon,

--- a/src/login-common/ssl-proxy-openssl.c
+++ b/src/login-common/ssl-proxy-openssl.c
@@ -716,7 +716,11 @@ void ssl_proxy_destroy(struct ssl_proxy *proxy)
 	if (proxy->io_plain_write != NULL)
 		io_remove(&proxy->io_plain_write);
 
-	(void)SSL_shutdown(proxy->ssl);
+	if (SSL_shutdown(proxy->ssl) != 1) {
+		/* if bidirectional shutdown fails we need to clear
+		   the error queue. */
+		openssl_iostream_clear_errors();
+	}
 
 	net_disconnect(proxy->fd_ssl);
 	net_disconnect(proxy->fd_plain);


### PR DESCRIPTION
If the SSL_shutdown-call fails (e.g. because the underlaying socket has
already been closed) OpenSSL puts the corresponding error into the
queue. We don't care about details so we need to clear the queue.

Otherwise the error will be pulled while error checking the next OpenSSL
call of an unrelated connection.

Issue can be reproduced by:
* setting `service imap-login { service_count = 0 }`
* imap-connection 1 (TLS) is doing a NOOP every second
* tcp-connection 2 is connecting to and immediately disconnecting from the SSL/TLS port (without any handshake).