### PR TITLE
Fix link failure against libressl.

### DIFF
--- a/src/lib-ssl-iostream/dovecot-openssl-common.c
+++ b/src/lib-ssl-iostream/dovecot-openssl-common.c
@@ -101,7 +101,7 @@ bool dovecot_openssl_common_global_unref(void)
 	ERR_remove_thread_state(NULL);
 #endif
 	ERR_free_strings();
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined (LIBRESSL_VERSION_NUMBER)
 	OPENSSL_cleanup();
 #endif
 	return FALSE;


### PR DESCRIPTION
libressl's behavior is like OpenSSL-1.0.1, not like OpenSSL-1.1. It does not have peculiar atexit(3) behavior the way OpenSSL-1.1 does, and this check is unnecessary. Moreover, it does not define OPENSSL_cleanup() so link fails.

see https://github.com/dovecot/core/commit/b4884ca2e67bb794786419d9e7b6140842b03bcc