### PR TITLE
Execute /etc/sysconfig/dovecot on init, if it exists

### DIFF
--- a/doc/dovecot-initd.sh
+++ b/doc/dovecot-initd.sh
@@ -19,6 +19,8 @@ DAEMON=/usr/local/sbin/dovecot
 # Uncomment to allow Dovecot daemons to produce core dumps.
 #ulimit -c unlimited
 
+[ -e /etc/sysconfig/dovecot ] && . /etc/sysconfig/dovecot
+
 test -x $DAEMON || exit 1
 set -e
 

--- a/doc/dovecot-initd.sh
+++ b/doc/dovecot-initd.sh
@@ -19,7 +19,11 @@ DAEMON=/usr/local/sbin/dovecot
 # Uncomment to allow Dovecot daemons to produce core dumps.
 #ulimit -c unlimited
 
+# RedHat config
 [ -e /etc/sysconfig/dovecot ] && . /etc/sysconfig/dovecot
+
+# Debian config
+[ -e /etc/default/dovecot ] && . /etc/default/dovecot
 
 test -x $DAEMON || exit 1
 set -e


### PR DESCRIPTION
Helps users set `ulimit`, `DAEMON` etc. without having to touch the init.d script.