### PR TITLE
Export per-service connection counts, and allow more configurable prefix

### DIFF
--- a/src/stats/client-export.c
+++ b/src/stats/client-export.c
@@ -499,7 +499,7 @@ static int client_export_iter_global(struct client *client)
 	str_printfa(cmd->str, "%ld", (long)g->reset_timestamp);
 	client_export_timeval(cmd->str, &g->last_update);
 	str_printfa(cmd->str, "\t%u\t%u\t%u\t",
-		    g->num_logins, g->num_cmds, g->num_connected_sessions);
+		    g->num_logins, g->num_cmds, g->num_connected_sessions_combined);
 	client_export_stats(cmd->str, g->stats);
 	str_append_c(cmd->str, '\n');
 	o_stream_nsend(client->output, str_data(cmd->str),

--- a/src/stats/mail-domain.c
+++ b/src/stats/mail-domain.c
@@ -51,7 +51,6 @@ void mail_domain_disconnected(struct mail_domain *domain)
 {
 	i_assert(domain->num_connected_sessions > 0);
 	domain->num_connected_sessions--;
-	mail_global_disconnected();
 }
 
 struct mail_domain *mail_domain_lookup(const char *name)

--- a/src/stats/mail-session.c
+++ b/src/stats/mail-session.c
@@ -46,6 +46,7 @@ static void mail_session_disconnect(struct mail_session *session)
 	i_assert(!session->disconnected);
 
 	mail_user_disconnected(session->user);
+	mail_global_disconnected(session->service);
 	if (session->ip != NULL)
 		mail_ip_disconnected(session->ip);
 
@@ -132,7 +133,7 @@ int mail_session_connect_parse(const char *const *args, const char **error_r)
 	}
 	global_memory_alloc(mail_session_memsize(session));
 
-	mail_global_login();
+	mail_global_login(args[2]);
 	return 0;
 }
 

--- a/src/stats/mail-stats.c
+++ b/src/stats/mail-stats.c
@@ -6,6 +6,7 @@
 #include "stats-carbon.h"
 #include "stats-settings.h"
 #include "str.h"
+#include "hash.h"
 
 struct mail_global mail_global_stats;
 
@@ -29,9 +30,6 @@ mail_global_stats_send(void *u0 ATTR_UNUSED)
 			    mail_global_stats.num_logins, ts);
 		str_printfa(str, "%s.cmds %u %lu\r\n", prefix,
 			    mail_global_stats.num_cmds, ts);
-		str_printfa(str, "%s.connected_sessions %u %lu\r\n", prefix,
-			    mail_global_stats.num_connected_sessions,
-			    ts);
 		str_printfa(str, "%s.last_reset %lu %lu\r\n", prefix,
 			    mail_global_stats.reset_timestamp, ts);
 		/* then export rest of the stats */
@@ -41,6 +39,18 @@ mail_global_stats_send(void *u0 ATTR_UNUSED)
 			stats_field_value(str, mail_global_stats.stats, i);
 			str_printfa(str, " %lu\r\n", ts);
 		}
+
+		/* Send per service session counts */
+		struct hash_iterate_context *iter;
+		const char *service;
+		unsigned int *count;
+		iter = hash_table_iterate_init(mail_global_stats.num_connected_sessions);
+		while (hash_table_iterate(iter, mail_global_stats.num_connected_sessions,
+		                          &service, &count)) {
+			str_printfa(str, "%s.connected_sessions_%s %u %lu\r\n", prefix,
+			            service, *count, ts);
+		}
+		hash_table_iterate_deinit(&iter);
 
 		/* and send them along */
 		(void)stats_carbon_send(stats_settings->carbon_server, str_c(str),
@@ -56,6 +66,8 @@ void mail_global_init(void)
 	mail_global_stats.to_stats_send = timeout_add(stats_settings->carbon_interval*1000,
 						      mail_global_stats_send,
 						      NULL);
+	hash_table_create(&mail_global_stats.num_connected_sessions,
+	                  default_pool, 0, str_hash, strcmp);
 }
 
 void mail_global_deinit(void)
@@ -63,19 +75,36 @@ void mail_global_deinit(void)
 	if (mail_global_stats.stats_send_ctx != NULL)
 		stats_carbon_destroy(&mail_global_stats.stats_send_ctx);
 	timeout_remove(&mail_global_stats.to_stats_send);
+	hash_table_destroy(&mail_global_stats.num_connected_sessions);
 	i_free(mail_global_stats.stats);
 }
 
-void mail_global_login(void)
+void mail_global_login(const char *service)
 {
 	mail_global_stats.num_logins++;
-	mail_global_stats.num_connected_sessions++;
+
+	unsigned int *count;
+	count = hash_table_lookup(mail_global_stats.num_connected_sessions, service);
+	if (count) {
+		(*count)++;
+	} else {
+		count = p_new(default_pool, unsigned int, 1);
+		*count = 1;
+		hash_table_insert(mail_global_stats.num_connected_sessions,
+		                  (const char *)i_strdup(service), count);
+	}
+	mail_global_stats.num_connected_sessions_combined++;
 }
 
-void mail_global_disconnected(void)
+void mail_global_disconnected(const char *service)
 {
-	i_assert(mail_global_stats.num_connected_sessions > 0);
-	mail_global_stats.num_connected_sessions--;
+	unsigned int *count;
+	count = hash_table_lookup(mail_global_stats.num_connected_sessions, service);
+	if (count) {
+		i_assert(*count > 0);
+		(*count)--;
+	}
+	mail_global_stats.num_connected_sessions_combined--;
 }
 
 void mail_global_refresh(const struct stats *diff_stats)

--- a/src/stats/mail-stats.c
+++ b/src/stats/mail-stats.c
@@ -23,7 +23,7 @@ mail_global_stats_send(void *u0 ATTR_UNUSED)
 	if (*stats_settings->carbon_name != '\0' &&
 	    *stats_settings->carbon_server != '\0') {
 		string_t *str = t_str_new(256);
-		const char *prefix = t_strdup_printf("dovecot.%s.global",
+		const char *prefix = t_strdup_printf("%s.global",
 						     stats_settings->carbon_name);
 		str_printfa(str, "%s.logins %u %lu\r\n", prefix,
 			    mail_global_stats.num_logins, ts);

--- a/src/stats/mail-stats.h
+++ b/src/stats/mail-stats.h
@@ -7,6 +7,8 @@
 #include "guid.h"
 #include "stats.h"
 
+#include "hash.h"
+
 struct stats_send_ctx;
 
 struct mail_command {
@@ -105,7 +107,8 @@ struct mail_global {
 	struct stats *stats;
 	unsigned int num_logins;
 	unsigned int num_cmds;
-	unsigned int num_connected_sessions;
+	unsigned int num_connected_sessions_combined;
+	HASH_TABLE(const char *, unsigned int *) num_connected_sessions;
 
 	struct timeout *to_stats_send;
 	struct stats_send_ctx *stats_send_ctx;
@@ -116,8 +119,8 @@ extern struct mail_global mail_global_stats;
 void mail_global_init(void);
 void mail_global_deinit(void);
 
-void mail_global_login(void);
-void mail_global_disconnected(void);
+void mail_global_login(const char *service);
+void mail_global_disconnected(const char *service);
 void mail_global_refresh(const struct stats *diff_stats);
 
 #endif


### PR DESCRIPTION
This implements two changes:
* Remove the hardcoded dovecot. prefix for carbon, as some organizations need specific carbon prefixes
* Split the global connection count into a hash table that has per-service connection counts, allowing carbon metrics for individual imap, pop3, lmtp, sieve, doveadm, etc... connection counts.