### PR TITLE
Deprecated function

### DIFF
--- a/src/lib-ssl-iostream/iostream-openssl-params.c
+++ b/src/lib-ssl-iostream/iostream-openssl-params.c
@@ -13,10 +13,19 @@ generate_dh_parameters(int bitsize, buffer_t *output, const char **error_r)
 {
         DH *dh;
 	unsigned char *p;
-	int len, len2;
+	int len, len2, success;
 
+#if OPENSSL_VERSION_NUMBER >= 0x00908000L
+	success = DH_generate_parameters_ex(dh, bitsize, DH_GENERATOR, NULL);
+#else
+	success = 1;
 	dh = DH_generate_parameters(bitsize, DH_GENERATOR, NULL, NULL);
 	if (dh == NULL) {
+		success = 0;
+	}
+#endif
+
+	if (success == 0) {
 		*error_r = t_strdup_printf(
 			"DH_generate_parameters(bits=%d, gen=%d) failed: %s",
 			bitsize, DH_GENERATOR, openssl_iostream_error());

--- a/src/lib-ssl-iostream/iostream-openssl-params.c
+++ b/src/lib-ssl-iostream/iostream-openssl-params.c
@@ -13,24 +13,34 @@ generate_dh_parameters(int bitsize, buffer_t *output, const char **error_r)
 {
         DH *dh;
 	unsigned char *p;
-	int len, len2, success;
+	int len, len2;
 
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L
-	success = DH_generate_parameters_ex(dh, bitsize, DH_GENERATOR, NULL);
+  dh = DH_new();
+  if (dh == NULL) {
+    *error_r = t_strdup_printf(
+			"DH_new() failed: %s",
+      openssl_iostream_error());
+		return -1;
+	}
+  if (!DH_generate_parameters_ex(dh, bitsize, DH_GENERATOR, NULL)) {
+    *error_r = t_strdup_printf(
+      "DH_generate_parameters_ex(bits=%d, gen=%d) failed: %s",
+      bitsize, DH_GENERATOR, openssl_iostream_error());
+      DH_free(dh);
+    return -1;
+  }
+
+  }
 #else
-	success = 1;
 	dh = DH_generate_parameters(bitsize, DH_GENERATOR, NULL, NULL);
 	if (dh == NULL) {
-		success = 0;
-	}
-#endif
-
-	if (success == 0) {
-		*error_r = t_strdup_printf(
+    *error_r = t_strdup_printf(
 			"DH_generate_parameters(bits=%d, gen=%d) failed: %s",
 			bitsize, DH_GENERATOR, openssl_iostream_error());
 		return -1;
 	}
+#endif
 
 	len = i2d_DHparams(dh, NULL);
 	if (len < 0) {

--- a/src/lib-ssl-iostream/iostream-openssl-params.c
+++ b/src/lib-ssl-iostream/iostream-openssl-params.c
@@ -27,10 +27,8 @@ generate_dh_parameters(int bitsize, buffer_t *output, const char **error_r)
     *error_r = t_strdup_printf(
       "DH_generate_parameters_ex(bits=%d, gen=%d) failed: %s",
       bitsize, DH_GENERATOR, openssl_iostream_error());
-      DH_free(dh);
+    DH_free(dh);
     return -1;
-  }
-
   }
 #else
 	dh = DH_generate_parameters(bitsize, DH_GENERATOR, NULL, NULL);


### PR DESCRIPTION
Function DH_generate_parameters has been deprecated since OpenSSL 0.9.8