### PR TITLE
Fix ssl-params on a FIPS enforced openssl.

### DIFF
--- a/doc/example-config/conf.d/10-ssl.conf
+++ b/doc/example-config/conf.d/10-ssl.conf
@@ -42,7 +42,12 @@ ssl_key = </etc/ssl/private/dovecot.pem
 # auth_ssl_username_from_cert=yes.
 #ssl_cert_username_field = commonName
 
-# DH parameters length to use.
+# DH parameters length to use. (Default 1024)
+#
+# Recommendation is a minimal length of 2048.
+#
+# See https://weakdh.org/sysadmin.html
+#
 #ssl_dh_parameters_length = 1024
 
 # SSL protocols to use

--- a/src/lib-ssl-iostream/iostream-openssl-params.c
+++ b/src/lib-ssl-iostream/iostream-openssl-params.c
@@ -44,9 +44,16 @@ generate_dh_parameters(int bitsize, buffer_t *output, const char **error_r)
 int openssl_iostream_generate_params(buffer_t *output, unsigned int dh_length,
 				     const char **error_r)
 {
-	if (generate_dh_parameters(512, output, error_r) < 0)
+	unsigned int minimal_dh_size = 512;
+	#ifdef OPENSSL_FIPS
+	if (FIPS_mode() > 0) {
+		minimal_dh_size = 2048;
+		i_warning("FIPS mode detected. Setting minimum DH params size from 512 to 2048. Accepting SSL connections after first start might take longer.");
+	};
+	#endif
+	if (generate_dh_parameters(minimal_dh_size, output, error_r) < 0)
 		return -1;
-	if (dh_length != 512) {
+	if (dh_length > minimal_dh_size) {
 		if (generate_dh_parameters(dh_length, output, error_r) < 0)
 			return -1;
 	}


### PR DESCRIPTION
In the old code we always generated a 512bit DH param to allow accepting
SSL connections early on low entropy systems. If openssl is in FIPS mode
generating such DH params is rejected by the library:

```
dovecot[1930]: ssl-params: Fatal: ssl_iostream_generate_params(2048) failed: DH_generate_parameters(bits=512, gen=2) failed: error:0506A06E:lib(5):func(106):reason(110), error:0506A003:lib(5):func(106):reason(3)
dovecot[1930]: ssl-params: Error: child process failed
```

If we now detect that openssl is in FIPS mode, we bump the minimal dh
param size to 2048. This can delay SSL connections on a low entropy
system after the first start. The code is guarded so that building on
openssl forks without FIPS support should work. Tested against libressl.

As the documentation patch points out you should also not use DH
params smaller than 2048 due to the logjam attack. Changing that part of
the behavior should be considered in a second patch.

In the 2.3 branch the whole SSL params process got dropped, so the patch
doesn't need to be ported.