### PR TITLE
WIP: auth: Disabling SMTP authentication in vpopmail users with NO_SMTP flag

### DIFF
--- a/src/auth/passdb-vpopmail.c
+++ b/src/auth/passdb-vpopmail.c
@@ -50,6 +50,9 @@ static bool vpopmail_is_disabled(struct auth_request *request,
 	if ((vpw->pw_flags & NO_POP) != 0 &&
 	    strcasecmp(request->service, "POP3") == 0)
 		return TRUE;
+	if ((vpw->pw_flags & NO_SMTP) != 0 &&
+	    strcasecmp(request->service, "SMTP") == 0)
+		return TRUE;
 	return FALSE;
 }
 


### PR DESCRIPTION
Even if the 0x800 bit in the `pw_flags` column in vpopmail passdb is set, all the mechs, like LOGIN/PLAIN/CRAM-MD5, of SMTP authentication are still enabled.
