### PR TITLE
lib-compression: Fix assert in i_stream_zlib_seek

### DIFF
--- a/src/lib-compression/istream-bzlib.c
+++ b/src/lib-compression/istream-bzlib.c
@@ -225,7 +225,7 @@ i_stream_bzlib_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 		stream->pos = stream->skip;
 	} else {
 		/* read and cache forward */
-		ssize_t ret = -1;
+		ssize_t ret;
 
 		do {
 			size_t avail = stream->pos - stream->skip;
@@ -234,6 +234,7 @@ i_stream_bzlib_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 				i_stream_skip(&stream->istream,
 					      v_offset -
 					      stream->istream.v_offset);
+				ret = -1;
 				break;
 			}
 

--- a/src/lib-compression/istream-lz4.c
+++ b/src/lib-compression/istream-lz4.c
@@ -204,7 +204,7 @@ i_stream_lz4_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 		stream->pos = stream->skip;
 	} else {
 		/* read and cache forward */
-		ssize_t ret = -1;
+		ssize_t ret;
 
 		do {
 			size_t avail = stream->pos - stream->skip;
@@ -213,6 +213,7 @@ i_stream_lz4_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 				i_stream_skip(&stream->istream,
 					      v_offset -
 					      stream->istream.v_offset);
+				ret = -1;
 				break;
 			}
 

--- a/src/lib-compression/istream-lzma.c
+++ b/src/lib-compression/istream-lzma.c
@@ -234,7 +234,7 @@ i_stream_lzma_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 		stream->pos = stream->skip;
 	} else {
 		/* read and cache forward */
-		ssize_t ret = -1;
+		ssize_t ret;
 
 		do {
 			size_t avail = stream->pos - stream->skip;
@@ -243,6 +243,7 @@ i_stream_lzma_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 				i_stream_skip(&stream->istream,
 					      v_offset -
 					      stream->istream.v_offset);
+				ret = -1;
 				break;
 			}
 

--- a/src/lib-compression/istream-zlib.c
+++ b/src/lib-compression/istream-zlib.c
@@ -397,7 +397,7 @@ i_stream_zlib_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 		stream->pos = stream->skip;
 	} else {
 		/* read and cache forward */
-		ssize_t ret = -1;
+		ssize_t ret;
 
 		do {
 			size_t avail = stream->pos - stream->skip;
@@ -406,6 +406,7 @@ i_stream_zlib_seek(struct istream_private *stream, uoff_t v_offset, bool mark)
 				i_stream_skip(&stream->istream,
 					      v_offset -
 					      stream->istream.v_offset);
+				ret = -1;
 				break;
 			}
 


### PR DESCRIPTION
There is a bug in lib-compression which causes panic if I try to use compressed (read-only) mbox as described here: https://wiki2.dovecot.org/Plugins/Zlib

As I can see bug was introduced by this commit:
https://github.com/dovecot/core/commit/6a1110d8757bb72fd90f4fe0857fd3aeaf8920ff (for dovecot 2.2.x)

More info about this problem:
https://www.dovecot.org/pipermail/dovecot/2017-July/108534.html
https://www.dovecot.org/list/dovecot/2017-February/106906.html

If needed, I can describe how this bug can be reproduced.
The fix was tested with gzip, bzip2 and xz compressed mboxes.