### PR TITLE
auth: cache: don't log password mismatch twice

### DIFF
--- a/src/auth/auth-request.c
+++ b/src/auth/auth-request.c
@@ -2484,6 +2484,16 @@ int auth_request_password_verify(struct auth_request *request,
 				 const char *crypted_password,
 				 const char *scheme, const char *subsystem)
 {
+	return auth_request_password_verify_log(request, plain_password,
+			crypted_password, scheme, subsystem, TRUE);
+}
+
+int auth_request_password_verify_log(struct auth_request *request,
+				 const char *plain_password,
+				 const char *crypted_password,
+				 const char *scheme, const char *subsystem,
+				 bool log_password_mismatch)
+{
 	const unsigned char *raw_password;
 	size_t raw_password_size;
 	const char *error;
@@ -2531,7 +2541,8 @@ int auth_request_password_verify(struct auth_request *request,
 					"Invalid password%s in passdb: %s",
 					password_str, error);
 	} else if (ret == 0) {
-		auth_request_log_password_mismatch(request, subsystem);
+		if (log_password_mismatch)
+			auth_request_log_password_mismatch(request, subsystem);
 	}
 	if (ret <= 0 && request->set->debug_passwords) T_BEGIN {
 		log_password_failure(request, plain_password,

--- a/src/auth/auth-request.h
+++ b/src/auth/auth-request.h
@@ -238,6 +238,11 @@ int auth_request_password_verify(struct auth_request *request,
 				 const char *plain_password,
 				 const char *crypted_password,
 				 const char *scheme, const char *subsystem);
+int auth_request_password_verify_log(struct auth_request *request,
+				 const char *plain_password,
+				 const char *crypted_password,
+				 const char *scheme, const char *subsystem,
+				 bool log_password_mismatch);
 
 void auth_request_log_debug(struct auth_request *auth_request,
 			    const char *subsystem,

--- a/src/auth/passdb-cache.c
+++ b/src/auth/passdb-cache.c
@@ -85,8 +85,9 @@ bool passdb_cache_verify_plain(struct auth_request *request, const char *key,
 		scheme = password_get_scheme(&cached_pw);
 		i_assert(scheme != NULL);
 
-		ret = auth_request_password_verify(request, password, cached_pw,
-						   scheme, AUTH_SUBSYS_DB);
+		ret = auth_request_password_verify_log(request, password, cached_pw,
+						   scheme, AUTH_SUBSYS_DB,
+						   !(node->last_success || neg_expired));
 
 		if (ret == 0 && (node->last_success || neg_expired)) {
 			/* a) the last authentication was successful. assume


### PR DESCRIPTION
If auth cache is enabled and the last auth was successful dovecot assumes the password has been changed and invalidates the cache which results in logging the same password mismatch twice.
This also applies to expired negative cache entries.

Background: We have `auth_verbose` enabled to provide login logging/tracking also for password mismatches.