### PR TITLE
Argon2 fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,7 +181,7 @@ AS_HELP_STRING([--with-solr], [Build with Solr full text search support]),
   want_solr=no)
 
 AC_ARG_WITH(sodium,
-AS_HELP_STRING([--with-sodium], [Build with libsodium support (enables argon2 and scrypt, default: auto)]),
+AS_HELP_STRING([--with-sodium], [Build with libsodium support (enables argon2, default: auto)]),
   TEST_WITH(sodium, $withval),
   want_sodium=auto)
 

--- a/src/auth/password-scheme-sodium.c
+++ b/src/auth/password-scheme-sodium.c
@@ -5,7 +5,7 @@
 #include <sodium.h>
 
 static void
-generate_argon2(const char *plaintext, const struct password_generate_params *params,
+generate_argon2i(const char *plaintext, const struct password_generate_params *params,
 		const unsigned char **raw_password_r, size_t *size_r)
 {
 	unsigned long long rounds = params->rounds;
@@ -22,11 +22,37 @@ generate_argon2(const char *plaintext, const struct password_generate_params *pa
 	else
 		memlimit = crypto_pwhash_argon2i_MEMLIMIT_INTERACTIVE;
 
-	if (crypto_pwhash_str(result, plaintext, strlen(plaintext), rounds, memlimit) < 0)
-		i_fatal("crypto_pwhash_str failed");
+	if (crypto_pwhash_argon2i_str(result, plaintext, strlen(plaintext), rounds, memlimit) < 0)
+		i_fatal("crypto_pwhash_argon2i_str failed");
 	*raw_password_r = (const unsigned char*)t_strdup(result);
 	*size_r = strlen(result);
 }
+
+#ifdef crypto_pwhash_ALG_ARGON2ID13
+static void
+generate_argon2id(const char *plaintext, const struct password_generate_params *params,
+		const unsigned char **raw_password_r, size_t *size_r)
+{
+	unsigned long long rounds = params->rounds;
+	size_t memlimit;
+	char result[crypto_pwhash_STRBYTES];
+
+	if (rounds == 0)
+		rounds = crypto_pwhash_argon2id_OPSLIMIT_INTERACTIVE;
+
+	if (rounds >= crypto_pwhash_argon2id_OPSLIMIT_SENSITIVE)
+		memlimit = crypto_pwhash_argon2id_MEMLIMIT_SENSITIVE;
+	else if (rounds >= crypto_pwhash_argon2id_OPSLIMIT_MODERATE)
+		memlimit = crypto_pwhash_argon2id_MEMLIMIT_MODERATE;
+	else
+		memlimit = crypto_pwhash_argon2id_MEMLIMIT_INTERACTIVE;
+
+	if (crypto_pwhash_argon2id_str(result, plaintext, strlen(plaintext), rounds, memlimit) < 0)
+		i_fatal("crypto_pwhash_argon2id_str failed");
+	*raw_password_r = (const unsigned char*)t_strdup(result);
+	*size_r = strlen(result);
+}
+#endif
 
 static int
 verify_argon2(const char *plaintext, const struct password_generate_params *params ATTR_UNUSED,
@@ -41,12 +67,19 @@ verify_argon2(const char *plaintext, const struct password_generate_params *para
 
 
 static const struct password_scheme sodium_schemes[] = {
-	{ "ARGON2", PW_ENCODING_NONE, 0, verify_argon2,
-	  generate_argon2 },
+	{ "ARGON2I", PW_ENCODING_NONE, 0, verify_argon2,
+	  generate_argon2i },
+#ifdef crypto_pwhash_ALG_ARGON2ID13
+	{ "ARGON2ID", PW_ENCODING_NONE, 0, verify_argon2,
+	  generate_argon2id },
+#endif
 };
 
 void password_scheme_register_sodium(void)
 {
+	if (sodium_init() < 0)
+		i_fatal("sodium_init failed");
+
 	for(size_t i = 0; i < N_ELEMENTS(sodium_schemes); i++)
 		password_scheme_register(&sodium_schemes[i]);
 }

--- a/src/auth/test-libpassword.c
+++ b/src/auth/test-libpassword.c
@@ -111,7 +111,7 @@ static void test_password_schemes(void)
 	test_password_scheme("SCRAM-SHA-1", "{SCRAM-SHA-1}4096,GetyLXdBuHzf1FWf8SLz2Q==,NA/OqmF4hhrsrB9KR7po+dliTGM=,QBiURvQaE6H6qYTmeghDHLANBFQ=", "test");
 	test_password_scheme("BLF-CRYPT", "{BLF-CRYPT}$2y$05$11ipvo5dR6CwkzwmhwM26OXgzXwhV2PyPuLV.Qi31ILcRcThQpEiW", "test");
 #ifdef HAVE_LIBSODIUM
-	test_password_scheme("ARGON2", "{ARGON2}$argon2i$v=19$m=32768,t=4,p=1$f2iuP4aUeNMrgu34fhOkkg$1XSZZMWlIs0zmE+snlUIcLADO3GXbA2O/hsQmmc317k", "test");
+	test_password_scheme("ARGON2I", "{ARGON2I}$argon2i$v=19$m=32768,t=4,p=1$f2iuP4aUeNMrgu34fhOkkg$1XSZZMWlIs0zmE+snlUIcLADO3GXbA2O/hsQmmc317k", "test");
 #endif
 }
 


### PR DESCRIPTION
The current `password-scheme-sodium` module mixes constants from a specific algorithm (Argon2i) with algorithm-independent functions.

`crypto_pwhash_str()` is not a synonym for Argon2i. It stands for "the recommended algorithm supported by the libsodium version installed on the system". Which is is not Argon2i any more on current versions.
And `crypto_pwhash_str_verify()` can verify any hash produced by any algorithm ever used by `pwhash_str()`.

This PR explicitly calls that Argon2i version of `pwhash_str()` when the Argon2i parameters are used.
It also adds support for Argon2id. For consistency, the initial scheme was thus renamed `ARGON2I`.

This PR also calls `sodium_init()`. Without proper initialization, only generic, slow implementations will be used. Doing so makes a huge difference, especially on recent Intel CPUs with AVX512.