### PR TITLE
Password authentication for redis dict driver

### DIFF
--- a/src/lib-dict/dict-redis.c
+++ b/src/lib-dict/dict-redis.c
@@ -13,6 +13,8 @@
 #define DICT_USERNAME_SEPARATOR '/'
 
 enum redis_input_state {
+	/* expecting +OK reply for AUTH */
+	REDIS_INPUT_STATE_AUTH,
 	/* expecting +OK reply for SELECT */
 	REDIS_INPUT_STATE_SELECT,
 	/* expecting $-1 / $<size> followed by GET reply */
@@ -45,7 +47,7 @@ struct redis_dict_reply {
 
 struct redis_dict {
 	struct dict dict;
-	char *username, *key_prefix, *expire_value;
+	char *username, *password, *key_prefix, *expire_value;
 	unsigned int timeout_msecs, db_id;
 
 	struct ioloop *ioloop, *prev_ioloop;
@@ -233,6 +235,7 @@ redis_conn_input_more(struct redis_connection *conn, const char **error_r)
 	switch (state) {
 	case REDIS_INPUT_STATE_GET:
 		i_unreached();
+	case REDIS_INPUT_STATE_AUTH:
 	case REDIS_INPUT_STATE_SELECT:
 	case REDIS_INPUT_STATE_MULTI:
 	case REDIS_INPUT_STATE_DISCARD:
@@ -367,6 +370,7 @@ redis_dict_init(struct dict *driver, const char *uri,
 		i_unreached();
 	dict->timeout_msecs = REDIS_DEFAULT_LOOKUP_TIMEOUT_MSECS;
 	dict->key_prefix = i_strdup("");
+	dict->password   = i_strdup("");
 
 	args = t_strsplit(uri, ":");
 	for (; *args != NULL; args++) {
@@ -409,6 +413,9 @@ redis_dict_init(struct dict *driver, const char *uri,
 					"Invalid timeout_msecs: %s", *args+14);
 				ret = -1;
 			}
+		} else if (strncmp(*args, "password=", 9) == 0) {
+			i_free(dict->password);
+			dict->password = i_strdup(*args + 9);
 		} else {
 			*error_r = t_strdup_printf("Unknown parameter: %s",
 						   *args);
@@ -416,6 +423,7 @@ redis_dict_init(struct dict *driver, const char *uri,
 		}
 	}
 	if (ret < 0) {
+		i_free(dict->password);
 		i_free(dict->key_prefix);
 		i_free(dict);
 		return -1;
@@ -458,6 +466,7 @@ static void redis_dict_deinit(struct dict *_dict)
 	array_free(&dict->input_states);
 	i_free(dict->expire_value);
 	i_free(dict->key_prefix);
+	i_free(dict->pasword);
 	i_free(dict->username);
 	i_free(dict);
 
@@ -488,6 +497,19 @@ redis_dict_get_full_key(struct redis_dict *dict, const char *key)
 	if (*dict->key_prefix != '\0')
 		key = t_strconcat(dict->key_prefix, key, NULL);
 	return key;
+}
+
+static void redis_dict_auth(struct redis_dict *dict)
+{
+	const char *cmd;
+	
+	if (*dict->password == '\0')
+		return;
+	
+	cmd = t_strdup_printf("*2\r\n$4\r\nAUTH\r\n$%d\r\n%s\r\n",
+			      (int)strlen(dict->password), dict->password);
+	o_stream_nsend_str(dict->conn.conn.output, cmd);
+	redis_input_state_add(dict, REDIS_INPUT_STATE_AUTH);
 }
 
 static void redis_dict_select_db(struct redis_dict *dict)
@@ -535,6 +557,9 @@ static int redis_dict_lookup(struct dict *_dict, pool_t pool, const char *key,
 		if (!dict->connected) {
 			/* wait for connection */
 			io_loop_run(dict->ioloop);
+			/* authenticate */
+			if (dict->connected)
+				redis_dict_auth(dict);
 		}
 
 		if (dict->connected) {
@@ -591,6 +616,9 @@ redis_transaction_init(struct dict *_dict)
 	} else if (!dict->connected) {
 		/* wait for connection */
 		redis_wait(dict);
+		/* authenticate */
+		if (dict->connected)
+			redis_dict_auth(dict);
 	}
 	if (dict->connected)
 		redis_dict_select_db(dict);


### PR DESCRIPTION
Support redis authentication using a standard password= argument in the redis dict driver. This change was proposed last year on the mailing list, I'm resubmitting here as pull request.