### PR TITLE
doveadm: fix protocol handshake order

### DIFF
--- a/src/doveadm/server-connection.c
+++ b/src/doveadm/server-connection.c
@@ -361,7 +361,6 @@ static void server_connection_input(struct server_connection *conn)
 				if (conn->minor > 0)
 					server_connection_start_multiplex(conn);
 				server_connection_authenticated(conn);
-				break;
 			} else if (strcmp(line, "-") == 0) {
 				if (!conn->handshaked &&
 				    server_connection_authenticate(conn) < 0) {


### PR DESCRIPTION
@cmouse while working on rebasing #54 I noticed the doveadm handshake is broken. I tracked this down to the new protocol version 1.1. The expected client version gets send to the client after the client sent the supported protocol. However with tcp or unix sockets the server sends the authentication result beforehand (in `client_connection_tcp_send_auth_handshake`) which results in invalid protocol version detection on client side.

In short the server is sending: `"+\nVERSION\tdoveadm-client\t1\t1\n"` (wrong) vs. `"VERSION\tdoveadm-client\t1\t1\n+\n"` (correct)
