### PR TITLE
str_escape speedup

### DIFF
--- a/src/lib/strescape.c
+++ b/src/lib/strescape.c
@@ -6,27 +6,28 @@
 
 const char *str_escape(const char *str)
 {
-	const char *p;
 	string_t *ret;
+	size_t i = 0, j = 0;
 
 	/* see if we need to quote it */
-	for (p = str; *p != '\0'; p++) {
-		if (IS_ESCAPED_CHAR(*p))
+	for (; str[i] != '\0'; ++i) {
+		if (IS_ESCAPED_CHAR(str[i]))
 			break;
 	}
 
-	if (*p == '\0')
+	if (str[i] == '\0')
 		return str;
 
 	/* quote */
-	ret = t_str_new((size_t) (p - str) + 128);
-	str_append_n(ret, str, (size_t) (p - str));
-
-	for (; *p != '\0'; p++) {
-		if (IS_ESCAPED_CHAR(*p))
+	ret = t_str_new(i + 128);
+	for (; str[i] != '\0'; ++i) {
+		if (IS_ESCAPED_CHAR(str[i])) {
+			str_append_n(ret, str + j, i - j);
 			str_append_c(ret, '\\');
-		str_append_c(ret, *p);
+			j = i;
+		}
 	}
+	str_append_n(ret, str + j, i - j);
 	return str_c(ret);
 }
 

--- a/src/lib/strescape.c
+++ b/src/lib/strescape.c
@@ -31,6 +31,20 @@ const char *str_escape(const char *str)
 	return str_c(ret);
 }
 
+void str_append_escaped(string_t *dest, const void *src, size_t src_size)
+{
+	const unsigned char *src_c = src;
+	size_t i = 0, j = 0;
+	for (; i < src_size; ++i) {
+		if (IS_ESCAPED_CHAR(src_c[i])) {
+			str_append_n(dest, src_c + j, i - j);
+			str_append_c(dest, '\\');
+			j = i;
+		}
+	}
+	str_append_n(dest, src_c + j, i - j);
+}
+
 void str_append_unescaped(string_t *dest, const void *src, size_t src_size)
 {
 	const unsigned char *src_c = src;

--- a/src/lib/strescape.h
+++ b/src/lib/strescape.h
@@ -1,10 +1,20 @@
 #ifndef STRESCAPE_H
 #define STRESCAPE_H
 
+#include "str.h"
+
 #define IS_ESCAPED_CHAR(c) ((c) == '"' || (c) == '\\' || (c) == '\'')
 
 /* escape all '\', '"' and "'" characters */
 const char *str_escape(const char *str);
+
+/* escape all '\', '"' and "'" characters, append to given string */
+void str_append_escaped(string_t *dest, const void *src, size_t src_size);
+
+static inline void str_append_escaped_str(string_t *dest, const string_t *src)
+{
+    str_append_escaped(dest, str_data(src), str_len(src));
+}
 
 /* remove all '\' characters, append to given string */
 void str_append_unescaped(string_t *dest, const void *src, size_t src_size);

--- a/src/lib/test-strescape.c
+++ b/src/lib/test-strescape.c
@@ -51,7 +51,7 @@ static void test_str_escape(void)
 	};
 	unsigned char buf[1 << CHAR_BIT];
 	const char *escaped, *tabstr, *unesc_str;
-	string_t *str;
+	string_t *str, *escaped_str;
 	unsigned int i;
 
 	test_begin("str_escape");
@@ -67,7 +67,15 @@ static void test_str_escape(void)
 	test_assert(escaped['\''+1] == '\'');
 	test_assert(escaped['\\'+2-1] == '\\'); /* 92 */
 	test_assert(escaped['\\'+2] == '\\');
-	test_assert(strcmp(str_escape("\\\\\"\"\'\'"),
+
+	escaped = "\\\\\"\"\'\'";
+	test_assert(strcmp(str_escape(escaped),
+			   "\\\\\\\\\\\"\\\"\\\'\\\'") == 0);
+
+	str = t_str_new(256);
+	escaped_str = t_str_new_const(escaped, strlen(escaped));
+	str_append_escaped_str(str, escaped_str);
+	test_assert(strcmp(str_c(str),
 			   "\\\\\\\\\\\"\\\"\\\'\\\'") == 0);
 	test_end();
 


### PR DESCRIPTION
This implementation is 3x faster on -O0 and 2x faster on -O2/-O3 in the worst case when a char to be escaped is the first char in a source string (for example, `"\'foo\'"`). It doesn't affect the perfomance when source string contains no escaped chars.

Code for benchmark:
```
for (int i = 0; i < 2000; ++i) T_BEGIN {
    for (int i = 0; i < 10000; ++i)
        str_escape("\'aaaaaaaaaabbbbbbbbbcccccccccdddddddddd\'");
} T_END;
```