### PR TITLE
Add auth_external_ignore_authzid setting

### DIFF
--- a/doc/example-config/conf.d/10-auth.conf
+++ b/doc/example-config/conf.d/10-auth.conf
@@ -93,6 +93,14 @@
 # CommonName. 
 #auth_ssl_username_from_cert = no
 
+# Ignore the authzid sent from the client when using 
+# auth_ssl_username_from_cert.  This works around various broken client
+# behavior where clients send either an authzid that the user cannot
+# modify or one that would be unknown to the user.  Setting this effectively
+# disables the ability to use certificates with a master user login where 
+# the authzid is used as the master user!
+#auth_external_ignore_authzid = no
+
 # Space separated list of wanted authentication mechanisms:
 #   plain login digest-md5 cram-md5 ntlm rpa apop anonymous gssapi otp skey
 #   gss-spnego

--- a/src/auth/auth-settings.c
+++ b/src/auth/auth-settings.c
@@ -261,6 +261,7 @@ static const struct setting_define auth_setting_defines[] = {
 	DEF(SET_STR, verbose_passwords),
 	DEF(SET_BOOL, ssl_require_client_cert),
 	DEF(SET_BOOL, ssl_username_from_cert),
+	DEF(SET_BOOL, external_ignore_authzid),
 	DEF(SET_BOOL, use_winbind),
 
 	DEF(SET_UINT, worker_max_count),
@@ -319,6 +320,7 @@ static const struct auth_settings auth_default_settings = {
 	.verbose_passwords = "no",
 	.ssl_require_client_cert = FALSE,
 	.ssl_username_from_cert = FALSE,
+	.external_ignore_authzid = FALSE,
 	.ssl_client_ca_dir = "",
 	.ssl_client_ca_file = "",
 

--- a/src/auth/auth-settings.h
+++ b/src/auth/auth-settings.h
@@ -73,6 +73,7 @@ struct auth_settings {
 	const char *verbose_passwords;
 	bool ssl_require_client_cert;
 	bool ssl_username_from_cert;
+	bool external_ignore_authzid;
 	bool use_winbind;
 
 	unsigned int worker_max_count;

--- a/src/auth/mech-external.c
+++ b/src/auth/mech-external.c
@@ -29,7 +29,8 @@ mech_external_auth_continue(struct auth_request *request,
 	}
 
 	if (*authzid != '\0' &&
-	    !auth_request_set_login_username(request, authzid, &error)) {
+            !request->set->auth_external_ignore_authzid &&
+            !auth_request_set_login_username(request, authzid, &error)) {
 		/* invalid login username */
 		auth_request_log_info(request, AUTH_SUBSYS_MECH,
 				      "login user: %s", error);


### PR DESCRIPTION
Trying this again. This adds the auth_external_ignore_authzid option so we can ignore the authzid sent during EXTERNAL authentication and using auth_ssl_username_from_cert.  This works around broken clients that may send a username the user can't modify (like Apple Mail) or demand the user enter a username they may not know (like Thunderbird).