### PR TITLE
Add ssl_ca_hash setting

### DIFF
--- a/doc/example-config/conf.d/10-ssl.conf
+++ b/doc/example-config/conf.d/10-ssl.conf
@@ -23,6 +23,22 @@ ssl_key = </etc/ssl/private/dovecot.pem
 # followed by the matching CRL(s). (e.g. ssl_ca = </etc/ssl/certs/ca.pem)
 #ssl_ca = 
 
+# A directory location with hashed trusted certifcate authorities and their
+# CRL lists. An example bash script to build these hashed using OpenSSL:
+# #!/bin/sh
+# for file in *.pem; do ln -s "$file" "$(openssl x509 -hash -noout -in "$file")".0; done
+# for file in *.crl; do ln -s "$file" "$(openssl crl -hash -noout -in "$file")".r0; done
+#
+# Some platforms may also come with the 'c_rehash' command which can also
+# create these links like so:
+#
+# c_rehash /etc/dovecot/yourcertdirectory
+#
+# These hashes only need to be built once unless you add a new CA!
+# 
+# Set this only if you intend to use ssl_verify_client_cert=yes.
+#ssl_ca_hash_dir = 
+
 # Require that CRL check succeeds for client certificates.
 #ssl_require_crl = yes
 

--- a/src/lib-master/master-service-ssl-settings.c
+++ b/src/lib-master/master-service-ssl-settings.c
@@ -18,6 +18,7 @@ master_service_ssl_settings_check(void *_set, pool_t pool, const char **error_r)
 static const struct setting_define master_service_ssl_setting_defines[] = {
 	DEF(SET_ENUM, ssl),
 	DEF(SET_STR, ssl_ca),
+	DEF(SET_STR, ssl_ca_hash_dir),
 	DEF(SET_STR, ssl_cert),
 	DEF(SET_STR, ssl_key),
 	DEF(SET_STR, ssl_alt_cert),
@@ -47,6 +48,7 @@ static const struct master_service_ssl_settings master_service_ssl_default_setti
 	.ssl = "no:yes:required",
 #endif
 	.ssl_ca = "",
+	.ssl_ca_hash_dir = "",
 	.ssl_cert = "",
 	.ssl_key = "",
 	.ssl_alt_cert = "",
@@ -113,8 +115,8 @@ master_service_ssl_settings_check(void *_set, pool_t pool ATTR_UNUSED,
 		return FALSE;
 	}
 #endif
-	if (set->ssl_verify_client_cert && *set->ssl_ca == '\0') {
-		*error_r = "ssl_verify_client_cert set, but ssl_ca not";
+	if (set->ssl_verify_client_cert && (*set->ssl_ca == '\0' && *set->ssl_ca_hash_dir == '\0')) {
+		*error_r = "ssl_verify_client_cert set, but ssl_ca or ssl_ca_hash_dir not";
 		return FALSE;
 	}
 
@@ -173,9 +175,11 @@ void master_service_ssl_settings_to_iostream_set(
 	i_zero(set_r);
 	set_r->min_protocol = p_strdup(pool, ssl_set->ssl_min_protocol);
 	set_r->cipher_list = p_strdup(pool, ssl_set->ssl_cipher_list);
-	/* NOTE: It's a bit questionable whether ssl_ca should be used for
-	   clients. But at least for now it's needed for login-proxy. */
+	/* NOTE: It's a bit questionable whether ssl_ca or ssl_ca_hash_dir
+	   should be used for clients. But at least for now it's needed
+           for login-proxy. */
 	set_r->ca = p_strdup(pool, ssl_set->ssl_ca);
+	set_r->ca_hash_dir = p_strdup(pool, ssl_set->ssl_ca_hash_dir);
 
 	switch (type) {
 	case MASTER_SERVICE_SSL_SETTINGS_TYPE_SERVER:

--- a/src/lib-master/master-service-ssl-settings.h
+++ b/src/lib-master/master-service-ssl-settings.h
@@ -7,6 +7,7 @@ struct ssl_iostream_settings;
 struct master_service_ssl_settings {
 	const char *ssl;
 	const char *ssl_ca;
+	const char *ssl_ca_hash_dir;
 	const char *ssl_cert;
 	const char *ssl_alt_cert;
 	const char *ssl_key;

--- a/src/lib-ssl-iostream/iostream-openssl-context.c
+++ b/src/lib-ssl-iostream/iostream-openssl-context.c
@@ -320,21 +320,28 @@ ssl_iostream_context_load_ca(struct ssl_iostream_context *ctx,
 			     const struct ssl_iostream_settings *set,
 			     const char **error_r)
 {
-	X509_STORE *store;
-	STACK_OF(X509_NAME) *xnames = NULL;
 	const char *ca_file, *ca_dir;
 	bool have_ca = FALSE;
 
 	if (set->ca != NULL) {
-		store = SSL_CTX_get_cert_store(ctx->ssl_ctx);
-		if (load_ca(store, set->ca, &xnames) < 0) {
+		if (load_ca(ctx->ssl_ctx, set->ca) < 0) {
 			*error_r = t_strdup_printf("Couldn't parse ssl_ca: %s",
 						   openssl_iostream_error());
 			return -1;
 		}
-		ssl_iostream_ctx_verify_remote_cert(ctx, xnames);
+		ssl_iostream_ctx_verify_remote_cert(ctx);
 		have_ca = TRUE;
 	}
+
+        if (set->ca_hash_dir != NULL) {
+                if (load_ca(ctx->ssl_ctx, set->ca_hash) < 0) {
+                        *error_r = t_strdup_printf("Couldn't parse ssl_ca_hash_dir: %s",
+                                                   openssl_iostream_error());
+                        return -1;
+                }
+                ssl_iostream_ctx_verify_remote_cert(ctx);
+                have_ca = TRUE;
+        }
 	ca_file = set->ca_file == NULL || *set->ca_file == '\0' ?
 		NULL : set->ca_file;
 	ca_dir = set->ca_dir == NULL || *set->ca_dir == '\0' ?
@@ -351,7 +358,7 @@ ssl_iostream_context_load_ca(struct ssl_iostream_context *ctx,
 
 	if (!have_ca && !set->allow_invalid_cert) {
 		*error_r = !ctx->client_ctx ?
-			"Can't verify remote client certs without CA (ssl_ca setting)" :
+			"Can't verify remote client certs without CA (ssl_ca or ssl_ca_hash_dir setting)" :
 			"Can't verify remote server certs without trusted CAs (ssl_client_ca_* settings)";
 		return -1;
 	}

--- a/src/lib-ssl-iostream/iostream-ssl.h
+++ b/src/lib-ssl-iostream/iostream-ssl.h
@@ -17,7 +17,7 @@ struct ssl_iostream_settings {
 	const char *min_protocol; /* both */
 	const char *cipher_list; /* both */
 	const char *curve_list; /* both */
-	const char *ca, *ca_file, *ca_dir; /* context-only */
+	const char *ca, *ca_hash_dir, *ca_file, *ca_dir; /* context-only */
 	/* alternative cert is for providing certificate using
 	   different key algorithm */
 	struct ssl_iostream_cert cert; /* both */


### PR DESCRIPTION
This adds a ssl_ca_hash option that points to a directory location with hashed trusted certifcate authorities and their CRLs for use when requiring client certificates for login.

In our use case, we have multiple root CAs, multiple intermediate CAs, with thousands of client certificates issued against them.  This makes for rather large CRL lists that the current ssl_ca option tries to pull into memory.  That makes for some bloated processes that can quickly eat up all available memory on the server.

The hashed option lets the process read the CRLs as needed on disk.