### PR TITLE
Fix arc4random check

### DIFF
--- a/m4/arc4random.m4
+++ b/m4/arc4random.m4
@@ -13,11 +13,11 @@ AC_DEFUN([DOVECOT_ARC4RANDOM], [
      [--with-libbsd],
      [Use libbsd (default is no)]
   ), [want_libbsd=$withval], [want_libbsd=no])
-  AC_CHECK_FUNC([arc4random], AC_DEFINE([HAVE_ARC4RANDOM], [1], [Define this if you arc4random()]), [
+  AC_CHECK_FUNC([arc4random_buf], AC_DEFINE([HAVE_ARC4RANDOM], [1], [Define this if you have arc4random_buf()]), [
       if test "$want_libbsd" = yes; then
-        AC_CHECK_LIB([bsd], [arc4random], [
+        AC_CHECK_LIB([bsd], [arc4random_buf], [
           LIBS="$LIBS -lbsd"
-          AC_DEFINE([HAVE_ARC4RANDOM], [1], [Define this if you arc4random()])
+          AC_DEFINE([HAVE_ARC4RANDOM], [1], [Define this if you have arc4random_buf()])
           AC_DEFINE([HAVE_LIBBSD], [1], [Define this if you have libbsd])
         ])
       fi


### PR DESCRIPTION
The configure script checks for arc4random() but the actual code uses arc4random_buf(). This breaks for FreeBSD <8.0 and MacOS X <10.7, which have the former but not the latter. This change (and an autoreconf run) solves the problem at the cost of not using the available ARC4 implementation.