### PR TITLE
fix login via PAM

### DIFF
--- a/dovecot.service.in
+++ b/dovecot.service.in
@@ -20,9 +20,7 @@ PrivateTmp=true
 NonBlocking=yes
 ProtectSystem=full
 PrivateDevices=true
-# disable this if you want to use apparmor plugin
-NoNewPrivileges=true
-CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_IPC_LOCK CAP_KILL CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_SYS_RESOURCE
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_IPC_LOCK CAP_KILL CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_SYS_RESOURCE CAP_AUDIT_WRITE
 
 # You can add environment variables with e.g.:
 #Environment='CORE_OUTOFMEM=1'


### PR DESCRIPTION
After upgrading to 2.3, PAM authentication stopped working:

Error in system's security log:
```
PAM audit_log_acct_message() failed: Operation not permitted
```
Error in `dovecot.log`:
```
auth-worker(*REMOVED*): Info: pam(*REMOVED*): pam_authenticate() failed: System error
```

Removing `NoNewPrivileges=true` and adding `CAP_AUDIT_WRITE` to `CapabilityBoundingSet` fixes this error.

It seems the option `NoNewPrivileges=true` is not only a problem for apparmor, but also for PAM.