### PR TITLE
lda: allow empty envelope sender

### DIFF
--- a/src/lda/main.c
+++ b/src/lda/main.c
@@ -332,7 +332,8 @@ int main(int argc, char *argv[])
 		case 'f':
 			/* envelope sender address */
 			if (smtp_address_parse_path(ctx.pool, optarg,
-				SMTP_ADDRESS_PARSE_FLAG_BRACKETS_OPTIONAL,
+				SMTP_ADDRESS_PARSE_FLAG_BRACKETS_OPTIONAL |
+					SMTP_ADDRESS_PARSE_FLAG_ALLOW_EMPTY,
 				&mail_from, &errstr) < 0) {
 				i_fatal_status(EX_USAGE,
 					"Invalid -f parameter: %s", errstr);


### PR DESCRIPTION
In case of bounces, envelope sender (-f parameter) must be empty
(RFCs 3461, 3463 & 3464 apply, I guess)