### PR TITLE
lib: json-parser: Fixed EOF detecting in values

### DIFF
--- a/src/lib/json-parser.c
+++ b/src/lib/json-parser.c
@@ -138,7 +138,7 @@ int json_parser_deinit(struct json_parser **_parser, const char **error_r)
 					   i_stream_get_name(parser->input),
 					   i_stream_get_error(parser->input));
 	} else if (parser->data == parser->end &&
-		   !i_stream_have_bytes_left(parser->input) &&
+		   parser->input->eof &&
 		   parser->state != JSON_STATE_DONE) {
 		*error_r = "Missing '}'";
 	} else {


### PR DESCRIPTION
This small test shows the problem

```
#include "lib.h"
#include "istream.h"
#include "json-parser.h"

int main(void)
{
	const char *str = "{\"a\":\"";
	//const char *str = "{\"a\":nul";
	//const char *str = "{\"a\":fals";
	//const char *str = "{\"a\":tru";

	struct istream *input;
	struct json_parser *parser;
	enum json_type type;
	const char *value, *error;
	int ret;

	input = i_stream_create_from_data(str, strlen(str));
	parser = json_parser_init(input);

	while ((ret = json_parse_next(parser, &type, &value)) == 1)
		;

	i_assert(ret == -1);

	ret = json_parser_deinit(&parser, &error);
	if (ret < 0)
		i_error("%s", error);

	i_stream_unref(&input);

	return 0;
}
```

When we reading value from input stream, we call `json_parser_update_input_pos()` function only in next state. So if value was broken, `i_stream_have_bytes_left` returns true because current position in stream was not changed.