### PR TITLE
fix: doveadm-who/kick out of order response

### DIFF
--- a/src/doveadm/doveadm-kick.c
+++ b/src/doveadm/doveadm-kick.c
@@ -126,6 +126,9 @@ kick_print_kicked(struct kick_context *ctx, const bool show_warning)
 		if (strcmp(users[i-1], users[i]) != 0)
 			doveadm_print(users[i]);
 	}
+
+	doveadm_print_flush();
+
 	if (cli)
 		printf("\n");
 

--- a/src/doveadm/doveadm-who.c
+++ b/src/doveadm/doveadm-who.c
@@ -256,6 +256,8 @@ static void who_print_user(const struct who_user *user)
 		str_truncate(str, str_len(str)-1);
 	str_append_c(str, ')');
 	doveadm_print(str_c(str));
+
+	doveadm_print_flush();
 }
 
 static void who_print(struct who_context *ctx)


### PR DESCRIPTION
doveadm-who and kick did not properly flush protocol output
after doveadm_print(), this caused out-of-order response to
clients, example:

C: <tab><tab>who<crlf>
S: +<crlf>
S: username<tab>[...]<missing_crlf>

correct response should have been
S: <username><tab>[...]<crlf>
S: +<crlf>

fixed by adding doveadm_print_flush() calls.