### PR TITLE
lib-http: server connection: Fix assert in case of bad request

### DIFF
--- a/src/lib-http/http-server-connection.c
+++ b/src/lib-http/http-server-connection.c
@@ -685,9 +685,9 @@ static void http_server_connection_input(struct connection *_conn)
 
 			switch (error_code) {
 			case HTTP_REQUEST_PARSE_ERROR_BROKEN_REQUEST:
-				conn->input_broken = TRUE;
 				/* fall through */
 			case HTTP_REQUEST_PARSE_ERROR_BAD_REQUEST:
+				conn->input_broken = TRUE;
 				http_server_request_fail(req, 400, "Bad Request");
 				break;
 			case HTTP_REQUEST_PARSE_ERROR_METHOD_TOO_LONG:


### PR DESCRIPTION
When sending this request to doveadm

`$ printf "GET / HTTP/1.1\r\n\r\nabc\r\n" | nc localhost 8080`

we get

```
Apr 28 16:45:00 testmachine dovecot: doveadm(10.8.16.220): http-server: conn 10.8.16.220:34980 [1]: Client sent invalid request: Missing Host header
Apr 28 16:45:00 testmachine dovecot: doveadm(10.8.16.220): http-server: conn 10.8.16.220:34980 [1]: Client sent invalid request: Unexpected character <CR> in request method
Apr 28 16:45:00 testmachine dovecot: doveadm(10.8.16.220): Panic: file http-server-response.c: line 60 (http_server_response_create): assertion failed: (!resp->submitted)