### PR TITLE
Close stderr along with stdout before daemonizing.

### DIFF
--- a/src/master/main.c
+++ b/src/master/main.c
@@ -861,6 +861,8 @@ int main(int argc, char *argv[])
 		i_fatal("dup2(dev_null_fd) failed: %m");
 	if (!foreground && dup2(dev_null_fd, STDOUT_FILENO) < 0)
 		i_fatal("dup2(dev_null_fd) failed: %m");
+	if (!foreground && dup2(dev_null_fd, STDERR_FILENO) < 0)
+		i_fatal("dup2(dev_null_fd) failed: %m");
 
 	pidfile_path =
 		i_strconcat(set->base_dir, "/"MASTER_PID_FILE_NAME, NULL);


### PR DESCRIPTION
This has been causing problems with SaltStack on FreeBSD:

https://github.com/saltstack/salt/issues/44848
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=228003