### PR TITLE
lib-storage: reintroduce mail_index_set_fsync_mode

### DIFF
--- a/src/lib-storage/index/index-storage.c
+++ b/src/lib-storage/index/index-storage.c
@@ -251,6 +251,8 @@ int index_storage_mailbox_alloc_index(struct mailbox *box)
 			return -1;
 		mail_index_set_cache_dir(box->index, cache_dir);
 	}
+	mail_index_set_fsync_mode(box->index,
+				  box->storage->set->parsed_fsync_mode, 0);
 	mail_index_set_lock_method(box->index,
 		box->storage->set->parsed_lock_method,
 		mail_storage_get_lock_timeout(box->storage, UINT_MAX));


### PR DESCRIPTION
I'm not sure if this is the right way to propose this: This fix is already in master as bf277f94101249133349c0560dad0463c821a2ef, but it would be really great if we could get this into the next 2.3 release.