### PR TITLE
lib/str.h: fix invalid conversion

### DIFF
--- a/src/lib/str.h
+++ b/src/lib/str.h
@@ -19,7 +19,7 @@ bool str_equals(const string_t *str1, const string_t *str2) ATTR_PURE;
 
 static inline const unsigned char *str_data(const string_t *str)
 {
-	return str->data;
+	return (const unsigned char*)str->data;
 }
 static inline size_t str_len(const string_t *str)
 {


### PR DESCRIPTION
/usr/include/dovecot/str.h: In function ‘const unsigned char* str_data(const string_t*)’:
/usr/include/dovecot/str.h:22:14: warning: invalid conversion from ‘const void*’ to ‘const unsigned char*’ [-fpermissive]
  return str->data;
         ~~~~~^~~~

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>