### PR TITLE
passdb-sql: clean usunsed password in memory

### DIFF
--- a/src/auth/passdb-sql.c
+++ b/src/auth/passdb-sql.c
@@ -119,6 +119,9 @@ static void sql_query_callback(struct sql_result *result,
 		passdb_handle_credentials(passdb_result, password, scheme,
 			sql_request->callback.lookup_credentials,
 			auth_request);
+		if ( password != NULL){
+			safe_memset(password, 0, strlen(password));
+		}
 		auth_request_unref(&auth_request);
 		return;
 	}
@@ -137,6 +140,7 @@ static void sql_query_callback(struct sql_result *result,
 	sql_request->callback.verify_plain(ret > 0 ? PASSDB_RESULT_OK :
 					   PASSDB_RESULT_PASSWORD_MISMATCH,
 					   auth_request);
+	safe_memset(password, 0, strlen(password));
 	auth_request_unref(&auth_request);
 }
 


### PR DESCRIPTION
On line [#109](https://github.com/dovecot/core/blob/2a3b7083ce4e62a8bd836f9983b223e98e9bc157/src/auth/passdb-sql.c#L109) we use strdup to copy _auth_request->passdb_password_ to _char * password_ variable. This variable is never directly cleaned in memory. I think that it would be good to add some _safe_memset_. I think that it's not breaking anything, but I need Your opinion.