### PR TITLE
Added linux-only fix to nfs_flush_chown_uid

### DIFF
--- a/src/lib/nfs-workarounds.c
+++ b/src/lib/nfs-workarounds.c
@@ -178,8 +178,10 @@ static void nfs_flush_chown_uid(const char *path)
 		i_error("nfs_flush_chown_uid: stat(%s) failed: %m", path);
 		return;
 	}
-	if (chown(path, uid, (gid_t)-1) < 0) {
-		if (errno == ESTALE || errno == EPERM || errno == ENOENT) {
+	/* we use chmod for this operation since chown has been seen to drop S_UID
+	   and S_GID bits from directory inodes in certain conditions */
+	if (chmod(path, st.st_mode & 07777) < 0) {
+		if (errno == EPERM) {
 			/* attr cache is flushed */
 			return;
 		}
@@ -187,7 +189,8 @@ static void nfs_flush_chown_uid(const char *path)
 			nfs_flush_file_handle_cache_parent_dir(path);
 			return;
 		}
-		i_error("nfs_flush_chown_uid: chown(%s) failed: %m", path);
+		i_error("nfs_flush_chown_uid: chmod(%s, %04o) failed: %m",
+				path, st.st_mode & 07777);
 	}
 #endif
 }


### PR DESCRIPTION
Observed with Netapp NFS mounted filesystems that the 'chown' call that is made in nfs-workarounds.c function nfs_flush_chown_uid results in file mode bits S_ISUID and S_ISGID being dropped.

This fix changes nfs_flush_chown_uid on Linux only to use stat + chmod to flush nfs attribute caches instead of the original chown call that could cause drop of S_ISUID/S_ISGID bits.

Also added backwards compatibility for non-linux to use the original chown method.

This branch is split into two commits where:
 - The first commit simply splits the code in preparation for the second commit, there is no changes to behaviour in the first commit
 - The second commit changes the linux-only chown call that was split out in the first commit to a chmod call

Note this is a re-opened pull request of a pull request that I closed because I accidentally performed the changes on the wrong branch:
https://github.com/dovecot/core/pull/79



