### PR TITLE
Fix XCLIENT PORT capability usage

### DIFF
--- a/src/submission-login/submission-proxy.c
+++ b/src/submission-login/submission-proxy.c
@@ -51,19 +51,19 @@ proxy_send_xclient(struct submission_client *client, struct ostream *output)
 	}
 
 	str = t_str_new(128);
-	str_append(str, "XCLIENT ");
+	str_append(str, "XCLIENT");
 	if (str_array_icase_find(client->proxy_xclient, "ADDR")) {
-		str_append(str, "ADDR=");
+		str_append(str, " ADDR=");
 		str_append(str, net_ip2addr(&client->common.ip));
 	}
 	if (str_array_icase_find(client->proxy_xclient, "PORT"))
-		str_printfa(str, "PORT=%u", client->common.remote_port);
+		str_printfa(str, " PORT=%u", client->common.remote_port);
 	if (str_array_icase_find(client->proxy_xclient, "SESSION")) {
-		str_append(str, "SESSION=");
+		str_append(str, " SESSION=");
 		str_append(str, client_get_session_id(&client->common));
 	}
 	if (str_array_icase_find(client->proxy_xclient, "TTL"))
-		str_printfa(str, "TTL=%u", client->common.proxy_ttl - 1);
+		str_printfa(str, " TTL=%u", client->common.proxy_ttl - 1);
 	if (str_array_icase_find(client->proxy_xclient, "FORWARD") &&
 		str_len(fwd) > 0) {
 		str_append(str, " FORWARD=");


### PR DESCRIPTION
If Postfix advertises "XCLIENT NAME ADDR PROTO HELO REVERSE_NAME PORT LOGIN", submission currently fails: Postfix is then unable to parse the XCLIENT request from Dovecot Submissiond:

```
< XCLIENT ADDR=185.115.176.12PORT=39074
> 501 5.5.4 Bad ADDR syntax: 185.115.176.12PORT=39074
```

This is my first pull request and I was yet unable to verify the changes - but as line 69 (FORWARD=) also implies the same logic, I'm confident that this patch is usable.