### PR TITLE
userdb-passwd: set errno=0 before each getpwent()

### DIFF
--- a/src/auth/userdb-passwd.c
+++ b/src/auth/userdb-passwd.c
@@ -172,8 +172,11 @@ static void passwd_iterate_next(struct userdb_iterate_context *_ctx)
 		return;
 	}
 
-	errno = 0;
-	while ((pw = getpwent()) != NULL) {
+	for (;;) {
+		errno = 0;
+		pw = getpwent();
+		if (pw == NULL)
+			break;
 		if (passwd_iterate_want_pw(pw, set)) {
 			_ctx->callback(pw->pw_name, _ctx->context);
 			return;


### PR DESCRIPTION
In https://bugs.gentoo.org/667118 Reuben Farrelly
noticed that running
    # doveadm user '*'
causes auth daemon to generate errors like:
    auth-worker(3585): Error: getpwent() failed: Invalid argument

This happens because on successful call getpwent()
now sets errno=EINVAL starting from glibc-2.28.
See https://sourceware.org/PR16004 for details.

The fix is to check 'errno' only when 'getpwent()' fails.

Reported-by: Reuben Farrelly
Bug: https://bugs.gentoo.org/667118
Bug: https://sourceware.org/PR16004
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>