### PR TITLE
Aliases

### DIFF
--- a/src/auth/db-passwd-file.h
+++ b/src/auth/db-passwd-file.h
@@ -10,6 +10,7 @@ struct passwd_user {
 	uid_t uid;
 	gid_t gid;
 
+	char *username;
 	char *home;
         char *password;
         char **extra_fields;
@@ -27,6 +28,7 @@ struct passwd_file {
 	int fd;
 
 	HASH_TABLE(char *, struct passwd_user *) users;
+	HASH_TABLE(char *, char *) aliases;
 };
 
 struct db_passwd_file {

--- a/src/auth/userdb-passwd-file.c
+++ b/src/auth/userdb-passwd-file.c
@@ -91,6 +91,15 @@ static void passwd_file_lookup(struct auth_request *auth_request,
 	if (pu->home != NULL)
 		auth_request_set_userdb_field(auth_request, "home", pu->home);
 
+	/* XXX
+	 I’m not sure which function best fit the intend:
+	 - auth_request_set_userdb_field
+	 - auth_request_set_username
+	 - auth_request_set_login_username
+	 */
+	if (pu->username != NULL)
+		auth_request_set_userdb_field(auth_request, "username", pu->username);
+
 	if (pu->extra_fields != NULL &&
 	    passwd_file_add_extra_fields(auth_request, pu->extra_fields) < 0) {
 		callback(USERDB_RESULT_INTERNAL_FAILURE, auth_request);


### PR DESCRIPTION
**Context**

- Dovecot is configured as a submission + imap service. It interacts with postfix with LMTP for mail box distribution and with submission relay for mail relaying.
- Postfix is configured as a server-to-server mail distribution service. It doesn’t do identification or authentication by itself.
- The whole mail system is used for private e-mailing, with small user base. It use a simple "passwd-file" driver.


**Purpose**

All identification and authentication is done by dovecot : when a mail client connects to imap, or when postfix want to distribute an e-mail to a local mail box.

I find it a bit unfortunate to "break" authentication encapsulation, and having postfix to handle aliasing to dovecot defined users.
So I did this modification in the code to be able to define aliases for users in the passwd-file files.

It works by adding at least one field named "aliases" on extra field, and by setting an alias user list, separated by `,` character.

When dovecot needs to do an authentication lookup, if the user is not found, it will try aliases to find the real user, and use this one as final authentication. So it's possible to login to imap with aliases, and send e-mail to alias to have them distributed in the real single user mail box.

I think it's easier to use than the MailboxAlias plugin, based on symbolic links.


I use it internally since a few days, and it seems to works as expected.


**Example**

An entry from "passwd-file" can look like this :
```
user:(password):_unknown:_unknown:(gecos):(home):(shell):aliases=alias1,alias2,alias3
```


**Weakness**

- It's perhaps more a personal grade patch than a PR grade change. The intend is mainly to push a bootstrap for a wide alias feature in dovecot than really include the current state of this patch.
- It always (re)set the authentication request username, even if it didn't change because of aliasing.
- The "aliases" extra-field is not prefixed with "userdb_".