### PR TITLE
config: reproducible output from settings-get.pl

### DIFF
--- a/src/config/settings-get.pl
+++ b/src/config/settings-get.pl
@@ -147,7 +147,7 @@ print "const struct setting_parser_info *all_default_roots[] = {\n";
 print "\t&master_service_setting_parser_info,\n";
 print "\t&master_service_ssl_setting_parser_info,\n";
 print "\t&smtp_submit_setting_parser_info,\n";
-foreach my $name (keys %parsers) {
+foreach my $name (sort(keys %parsers)) {
   my $module = $parsers{$name};
   next if (!$module);
 


### PR DESCRIPTION
If the same source gets built twice ('build same source on different
hosts at different times') the resulting files may differ.
Fix this by sorting the hash keys before usage.

Signed-off-by: Olaf Hering <olaf@aepfle.de>