### PR TITLE
WIP: Remove redundant getpwnam() in bsdauth.

### DIFF
--- a/src/auth/passdb-bsdauth.c
+++ b/src/auth/passdb-bsdauth.c
@@ -18,20 +18,38 @@ bsdauth_verify_plain(struct auth_request *request, const char *password,
 		    verify_plain_callback_t *callback)
 {
 	const char *type;
-	int result;
+	auth_session_t *result;
 
 	e_debug(authdb_event(request), "lookup");
 
 	/* check if the auth is valid */
 	type = t_strdup_printf("auth-%s", request->service);
-	result = auth_userokay(request->user, NULL, t_strdup_noconst(type),
+	result = auth_usercheck(request->user, NULL, t_strdup_noconst(type),
 			       t_strdup_noconst(password));
 
-	if (result == 0) {
+	if (auth_getstate(result) == 0) {
 		auth_request_log_password_mismatch(request, AUTH_SUBSYS_DB);
 		callback(PASSDB_RESULT_PASSWORD_MISMATCH, request);
 		return;
 	}
+
+	/* make sure we're using the username as defined by the database.
+	 * On OpenBSD, auth "styles" will translate a request->user of "name:style"
+	 * to "name" authenticated via "style"; or the default auth style on a system
+	 * might do something unusual to map any input to any username it wants.
+	 * See authenticate(3).
+	 */
+	if(auth_getpwd(result) == NULL) {
+		/* FIXME: internal error?
+		 * It would be strange but not impossible to
+		 * accept a user with missing account details.
+		 */
+		auth_request_set_field(request, "user", NULL, NULL);
+	} else {
+		auth_request_set_field(request, "user", auth_getpwd(result)->pw_name, NULL);
+	}
+
+	auth_close(result); // should equal the earlier auth_getstate()
 
 	callback(PASSDB_RESULT_OK, request);
 }


### PR DESCRIPTION
auth_userokay() already checks that the username is valid, but more than that it allows the flexible OpenBSD auth system which, if the admin has enabled it in login.conf,  allows the user to *choose* their authentication style, for example `yubikey` or `skey` or other customized authenticators. Removing this makes dovecot compatible with one-time passwords from skeyinit or oath-toolkit.

(Though, as an aside, the extra check did protect dovecot from [CVE-2019-19521](https://www.openwall.com/lists/oss-security/2019/12/04/5), so that was good)

See https://man.openbsd.org/auth_userokay and https://man.openbsd.org/login.conf.5.