### PR TITLE
lib-ssl-iostream: Do not build static test-iostream-ssl

### DIFF
--- a/src/lib-ssl-iostream/Makefile.am
+++ b/src/lib-ssl-iostream/Makefile.am
@@ -46,7 +46,6 @@ test_libs = \
 	../lib/liblib.la
 
 test_iostream_ssl_SOURCES = test-iostream-ssl.c
-test_iostream_ssl_LDFLAGS = -static
 test_iostream_ssl_LDADD = $(test_libs) $(SSL_LIBS) $(DLLIB)
 test_iostream_ssl_DEPENDENCIES = $(test_libs)
 


### PR DESCRIPTION
Fixes broken static build:
https://dovecot.org/pipermail/dovecot/2019-October/117326.html

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>