### PR TITLE
man: Fix message UID in doveadm sync -1 example

### DIFF
--- a/doc/man/doveadm-sync.1.in
+++ b/doc/man/doveadm-sync.1.in
@@ -97,7 +97,7 @@ Date+Message\-ID headers. UID 6 is not seen in destination so it's copied.
 If both source and destination have UID 6, but the messages are different,
 the headers don't match and both the messages are kept in the destination but
 they're given new UIDs 7 and 8 just to be sure any client didn't get confused
-about what UID 11 actually was. Thus, one\-way sync begins to quickly diverge
+about what UID 6 actually was. Thus, one\-way sync begins to quickly diverge
 from the source mailbox once changes start to occur on either side; one\-way
 sync should therefore normally only be used within a short period of time
 after a


### PR DESCRIPTION
Quick doc fix. Should be obvious: source message UID is given as 6 above in L97, so it's probably a typo / edit-artifact in L100.