### PR TITLE
Use net_gethostbyname() to resolve hosts in redis/memcached dict URI

### DIFF
--- a/src/lib-dict/dict-memcached-ascii.c
+++ b/src/lib-dict/dict-memcached-ascii.c
@@ -404,7 +404,7 @@ memcached_ascii_dict_init(struct dict *driver, const char *uri,
 			ret = net_gethostbyname(*args+5, &ips, &ips_count);
 			if (ret != 0) {
 				*error_r = t_strdup_printf("net_gethostbyname() failed: %s",
-										   net_gethosterror(ret));
+							   net_gethosterror(ret));
 				ret = -1;
 			} else {
 				dict->ip = ips[0];

--- a/src/lib-dict/dict-memcached.c
+++ b/src/lib-dict/dict-memcached.c
@@ -197,7 +197,7 @@ memcached_dict_init(struct dict *driver, const char *uri,
 			ret = net_gethostbyname(*args+5, &ips, &ips_count);
 			if (ret != 0) {
 				*error_r = t_strdup_printf("net_gethostbyname() failed: %s",
-										   net_gethosterror(ret));
+							   net_gethosterror(ret));
 				ret = -1;
 			} else {
 				dict->ip = ips[0];

--- a/src/lib-dict/dict-memcached.c
+++ b/src/lib-dict/dict-memcached.c
@@ -173,6 +173,8 @@ memcached_dict_init(struct dict *driver, const char *uri,
 		    struct dict **dict_r, const char **error_r)
 {
 	struct memcached_dict *dict;
+	struct ip_addr *ips;
+	unsigned int ips_count;
 	const char *const *args;
 	int ret = 0;
 
@@ -192,10 +194,13 @@ memcached_dict_init(struct dict *driver, const char *uri,
 	args = t_strsplit(uri, ":");
 	for (; *args != NULL; args++) {
 		if (str_begins(*args, "host=")) {
-			if (net_addr2ip(*args+5, &dict->ip) < 0) {
-				*error_r = t_strdup_printf("Invalid IP: %s",
-							   *args+5);
+			ret = net_gethostbyname(*args+5, &ips, &ips_count);
+			if (ret != 0) {
+				*error_r = t_strdup_printf("net_gethostbyname() failed: %s",
+										   net_gethosterror(ret));
 				ret = -1;
+			} else {
+				dict->ip = ips[0];
 			}
 		} else if (str_begins(*args, "port=")) {
 			if (net_str2port(*args+5, &dict->port) < 0) {

--- a/src/lib-dict/dict-redis.c
+++ b/src/lib-dict/dict-redis.c
@@ -382,7 +382,7 @@ redis_dict_init(struct dict *driver, const char *uri,
 			ret = net_gethostbyname(*args+5, &ips, &ips_count);
 			if (ret != 0) {
 				*error_r = t_strdup_printf("net_gethostbyname() failed: %s",
-										   net_gethosterror(ret));
+							   net_gethosterror(ret));
 				ret = -1;
 			} else {
 				ip = ips[0];


### PR DESCRIPTION
This patch enables the use of host names in the redis and memcached dict URI, for example `redis:host=redis.default.svc.cluster.local`.

This is useful in containerized environments such as Kubernetes, where hard coding an ephemeral IP address is not an option.