### PR TITLE
Fix bugs in smtp server

### DIFF
--- a/src/lib-smtp/smtp-server-cmd-data.c
+++ b/src/lib-smtp/smtp-server-cmd-data.c
@@ -654,7 +654,7 @@ void smtp_server_cmd_bdat(struct smtp_server_cmd_ctx *cmd,
 		}
 	}
 
-	if (ret > 0 || size > 0) {
+	if (ret > 0 || (size > 0 && conn->smtp_parser)) {
 		/* read/skip data even in case of error, as long as size is
 		   known */
 		input = smtp_command_parse_data_with_size(conn->smtp_parser,

--- a/src/lib-smtp/smtp-server-cmd-helo.c
+++ b/src/lib-smtp/smtp-server-cmd-helo.c
@@ -157,7 +157,7 @@ smtp_server_cmd_ehlo_reply_create(struct smtp_server_cmd_ctx *cmd)
 	unsigned int extra_caps_count, i, j;
 	struct smtp_server_reply *reply;
 
-	i_assert(cmd->cmd->reg->func == smtp_server_cmd_ehlo);
+	i_assert(cmd->cmd->reg->func == smtp_server_cmd_ehlo || cmd->cmd->reg->func == smtp_server_cmd_helo);
 	reply = smtp_server_reply_create_ehlo(cmd->cmd);
 
 	if (helo_data->helo.old_smtp)


### PR DESCRIPTION
`smtp_server_cmd_bdat` calls `smtp_command_parse_data_with_size` with first parameter being `conn->smtp_parser` which may be assigned to NULL by the previous call to `smtp_server_reply` ending up calling `smtp_server_connection_terminate` with the condition `if conn->bad_counter > conn->set.max_bad_commands`

cf https://hackerone.com/bugs?report_id=831290

The assert needs to be extended because `smtp_server_cmd_helo_run` can call `smtp_server_cmd_ehlo_reply_default`