### PR TITLE
lib-compression: fix length checks for zlib header

### DIFF
--- a/src/lib-compression/istream-zlib.c
+++ b/src/lib-compression/istream-zlib.c
@@ -100,12 +100,12 @@ static int i_stream_zlib_read_header(struct istream_private *stream)
 		return -1;
 	}
 	if ((data[3] & GZ_FLAG_FEXTRA) != 0) {
-		if (pos + 2 < size)
+		if (pos + 2 > size)
 			return 0;
 
 		fextra_size = le16_to_cpu_unaligned(&data[pos]);
 		pos += 2;
-		if (pos + fextra_size < size)
+		if (pos + fextra_size > size)
 			return 0;
 		pos += fextra_size;
 	}
@@ -122,7 +122,7 @@ static int i_stream_zlib_read_header(struct istream_private *stream)
 		} while (data[pos++] != '\0');
 	}
 	if ((data[3] & GZ_FLAG_FHCRC) != 0) {
-		if (pos + 2 < size)
+		if (pos + 2 > size)
 			return 0;
 		pos += 2;
 	}


### PR DESCRIPTION
Buffer over-read with input such as `\x1f\x8b\x01Dovec/\x01\xbf`