### PR TITLE
fix one byte overread in parse_angle_addr

### DIFF
--- a/src/lib-mail/message-address.c
+++ b/src/lib-mail/message-address.c
@@ -177,7 +177,7 @@ static int parse_angle_addr(struct message_address_parser_context *ctx,
 	if (*ctx->parser.data == '@') {
 		if (parse_domain_list(ctx) > 0 && *ctx->parser.data == ':') {
 			ctx->parser.data++;
-		} else if (parsing_path && *ctx->parser.data != ':') {
+		} else if (parsing_path && (ctx->parser.data >= ctx->parser.end || *ctx->parser.data != ':')) {
 			return -1;
 		} else {
 			if (ctx->fill_missing)


### PR DESCRIPTION
Cf https://hackerone.com/bugs?report_id=836045

Found by fuzzing `message_address_parse_path`

For now, binaries are safe as 
> All of the callers to message_address_parse_path() pass it a pointer to a NUL-terminated string.

