### PR TITLE
Fix haproxy PROXY protocol LOCAL type connection behavior when header includes address information or TLVs

### DIFF
--- a/src/lib-master/master-service-haproxy.c
+++ b/src/lib-master/master-service-haproxy.c
@@ -387,6 +387,7 @@ master_service_haproxy_read(struct master_service_haproxy_conn *hpconn)
 			/* keep local connection address for LOCAL */
 			/*i_debug("haproxy(v2): Local connection (rip=%s)",
 				net_ip2addr(real_remote_ip));*/
+			i = size; /* we should skip all the remaining data which can be present in PROXY protocol */
 			break;
 		case HAPROXY_CMD_PROXY:
 			if ((hdr->fam & 0x0f) != HAPROXY_SOCK_STREAM) {


### PR DESCRIPTION
PROXY protocol LOCAL type headers can actually include supplementary information (addresses, TLVs) which need to be skipped to correctly handle the header. Fixes Invalid TLV bug with haproxy 2.0.14 service checks.

More info here: https://github.com/haproxy/haproxy/issues/511
And here: https://www.mail-archive.com/haproxy@formilux.org/msg36890.html