### PR TITLE
Document command/args destination format to sync/backup.

### DIFF
--- a/doc/man/doveadm-sync.1.in
+++ b/doc/man/doveadm-sync.1.in
@@ -295,6 +295,10 @@ The default port is specified by
 .TP
 .BI tcps: host[:port]
 This is the same as tcp, but with SSL.
+.TP
+.BI command\ [arg1\ [,\ arg2,\ ..]]
+Runs a local command that connects its standard input & output
+to a dsync server.
 .RE
 .\"------------------------------------------------------------------------
 .SH "EXIT STATUS"


### PR DESCRIPTION
Per a recent mailing list discussion thread, I noted that the doveadm sync/backup format where _destination_ is a command and arguments is not mentioned in the relevant man page.

This intends to correct for that. I wanted to include Sami’s sample command:
```
doveadm backup -u john -R ssh sshuser@remote "sudo /usr/bin/doveadm dsync-server -u john"
```
… as an example, but then I realized that `dsync-server` doesn’t appear to be documented, either. :(