### PR TITLE
systemd integration: notify service manager when ready

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,7 @@ uninstall-hook:
 	rm $(DESTDIR)$(pkglibdir)/dovecot-config
 
 if HAVE_SYSTEMD
-CLEANFILES = $systedmsystemunit_DATA
+CLEANFILES = $(systemdsystemunit_DATA)
 endif
 
 DISTCLEANFILES = \

--- a/dovecot.service.in
+++ b/dovecot.service.in
@@ -14,9 +14,8 @@ Documentation=http://wiki2.dovecot.org/
 After=local-fs.target network-online.target
 
 [Service]
-Type=simple
+Type=notify
 ExecStart=@sbindir@/dovecot -F
-PIDFile=@rundir@/master.pid
 ExecReload=@bindir@/doveadm reload
 ExecStop=@bindir@/doveadm stop
 PrivateTmp=true

--- a/src/lib-master/master-service-settings.c
+++ b/src/lib-master/master-service-settings.c
@@ -62,7 +62,7 @@ static const struct setting_define master_service_setting_defines[] = {
 
 /* <settings checks> */
 #ifdef HAVE_SYSTEMD
-#  define ENV_SYSTEMD " LISTEN_PID LISTEN_FDS"
+#  define ENV_SYSTEMD " LISTEN_PID LISTEN_FDS NOTIFY_SOCKET"
 #else
 #  define ENV_SYSTEMD ""
 #endif

--- a/src/master/main.c
+++ b/src/master/main.c
@@ -26,6 +26,9 @@
 #include "service-process.h"
 #include "service-log.h"
 #include "dovecot-version.h"
+#ifdef HAVE_SYSTEMD
+#  include "sd-daemon.h"
+#endif
 
 #include <stdio.h>
 #include <unistd.h>
@@ -544,6 +547,9 @@ static void main_init(const struct master_settings *set)
 	master_clients_init();
 
 	services_monitor_start(services);
+#ifdef HAVE_SYSTEMD
+	sd_notify(0, "READY=1");
+#endif
 	startup_finished = TRUE;
 }
 


### PR DESCRIPTION
With Type=simple or Type=forking, systemd does not really know when the
service is ready to accept connections and might start depending
services too early. Use Type=notify to explicitly tell the service
manager when the service is ready.

For a real problem caused by assuming readiness too early, please see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=951722

For the meaning of the service type and details of the readiness
protocol, see also the following links:
https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=
https://www.freedesktop.org/software/systemd/man/sd_notify.html

As discussed in the last link, more elaborate state notifications are
possible. This patch only implements the most basic part.

Original patch prepared by Michael Biebl, with slight modification.


A second commit fixes an obvious typo in Makefile.am. I believe
the brackets are needed as well?