### PR TITLE
null-terminate sun_path

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1274,7 +1274,7 @@ v2.2.26 2016-10-27  Timo Sirainen <tss@iki.fi>
 	- zlib, IMAP BINARY: Fixed internal caching when accessing multiple
 	  newly created mails. They all had UID=0 and the next mail could have
 	  wrongly used the previously cached mail.
-	- doveadm stats reset wasn't reseting all the stats.
+	- doveadm stats reset wasn't resetting all the stats.
 	- auth_stats=yes: Don't update num_logins, since it doubles them when
 	  using with mail stats.
 	- quota count: Fixed deadlocks when updating vsize header.

--- a/src/director/director-connection.c
+++ b/src/director/director-connection.c
@@ -875,7 +875,7 @@ static bool director_cmd_director(struct director_connection *conn,
 
 		/* already have this. just reset its last_network_failure
 		   timestamp, since it might be up now, but only if this
-		   isn't part of the handshake. (if it was, reseting the
+		   isn't part of the handshake. (if it was, resetting the
 		   timestamp could cause us to rapidly keep trying to connect
 		   to it) */
 		if (conn->handshake_received)

--- a/src/lib-index/mail-index-transaction-finish.c
+++ b/src/lib-index/mail-index-transaction-finish.c
@@ -53,7 +53,7 @@ ext_reset_update_atomic(struct mail_index_transaction *t,
 
 	array_idx_set(&t->ext_reset_ids, ext_id, &reset_id);
 
-	/* reseting existing data is optional */
+	/* resetting existing data is optional */
 	if (array_is_created(&t->ext_resets)) {
 		reset = array_idx_modifiable(&t->ext_resets, ext_id);
 		if (reset->new_reset_id == (uint32_t)-1)

--- a/src/lib-index/mail-index.h
+++ b/src/lib-index/mail-index.h
@@ -327,7 +327,7 @@ void mail_index_set_lock_method(struct mail_index *index,
    use the default. */
 void mail_index_set_optimization_settings(struct mail_index *index,
 	const struct mail_index_optimization_settings *set);
-/* When creating a new index file or reseting an existing one, add the given
+/* When creating a new index file or resetting an existing one, add the given
    extension header data immediately to it. */
 void mail_index_set_ext_init_data(struct mail_index *index, uint32_t ext_id,
 				  const void *data, size_t size);

--- a/src/lib-index/mail-transaction-log-file.c
+++ b/src/lib-index/mail-transaction-log-file.c
@@ -760,7 +760,7 @@ mail_transaction_log_file_create2(struct mail_transaction_log_file *file,
 		return -1;
 
 	if (reset) {
-		/* don't reset modseqs. if we're reseting due to rebuilding
+		/* don't reset modseqs. if we're resetting due to rebuilding
 		   indexes we'll probably want to keep uidvalidity and in such
 		   cases we really don't want to shrink modseqs. */
 		file->hdr.prev_file_seq = 0;

--- a/src/lib-storage/index/index-sync-pvt.c
+++ b/src/lib-storage/index/index-sync-pvt.c
@@ -181,7 +181,7 @@ index_mailbox_sync_pvt_index(struct index_mailbox_sync_pvt_context *ctx,
 	} else {
 		/* mailbox created/recreated */
 		reset = TRUE;
-		i_info("Mailbox %s UIDVALIDITY changed (%u -> %u), reseting private index",
+		i_info("Mailbox %s UIDVALIDITY changed (%u -> %u), resetting private index",
 		       ctx->box->vname, hdr_pvt->uid_validity,
 		       hdr_shared->uid_validity);
 	}

--- a/src/master/sd-daemon.c
+++ b/src/master/sd-daemon.c
@@ -344,7 +344,7 @@ int sd_notify(int unset_environment, const char *state) {
                 return 0;
 
         /* Must be an abstract socket, or an absolute path */
-        if ((e[0] != '@' && e[0] != '/') || e[1] == 0) {
+        if ((e[0] != '@' && e[0] != '/') || e[1] == 0 || strlen(e) > (sizeof(sockaddr.un.sun_path)-1)) {
                 r = -EINVAL;
                 goto finish;
         }
@@ -356,7 +356,7 @@ int sd_notify(int unset_environment, const char *state) {
 
         memset(&sockaddr, 0, sizeof(sockaddr));
         sockaddr.sa.sa_family = AF_UNIX;
-        strncpy(sockaddr.un.sun_path, e, sizeof(sockaddr.un.sun_path));
+        strncpy(sockaddr.un.sun_path, e, sizeof(sockaddr.un.sun_path)-1);
 
         if (sockaddr.un.sun_path[0] == '@')
                 sockaddr.un.sun_path[0] = 0;


### PR DESCRIPTION
 master/sd-daemon: null-terminate sun_path

```
In file included from /usr/include/string.h:495,
                 from /usr/include/x86_64-linux-gnu/sys/un.h:37,
                 from sd-daemon.c:34:
In function 'strncpy',
    inlined from 'sd_notify' at sd-daemon.c:359:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: '__builtin_strncpy' specified bound 108 equals destination size [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```