### PR TITLE
Lua: Fix FTBFS with Lua-5.4

### DIFF
--- a/src/lib-lua/dlua-dovecot.c
+++ b/src/lib-lua/dlua-dovecot.c
@@ -282,7 +282,7 @@ void dlua_push_event(struct dlua_script *script, struct event *event)
 	luaL_setmetatable(script->L, DLUA_EVENT);
 
 	/* we need to attach gc to userdata to support older lua*/
-	struct event **ptr = lua_newuserdata(script->L, sizeof(struct event*));
+	struct event **ptr = lua_newuserdatauv(script->L, sizeof(struct event*));
 	*ptr = event;
 	lua_createtable(script->L, 0, 1);
 	lua_pushcfunction(script->L, dlua_event_gc);


### PR DESCRIPTION
When building with Lua-5.4, dovecot-2.3.11.3 will fail to build from source. This appears to be due to changes in the Lua API in version 5.4 (see https://www.lua.org/manual/5.4/manual.html):

" Full userdata now has an arbitrary number of associated user values. Therefore, the functions lua_newuserdata, lua_setuservalue, and lua_getuservalue were replaced by lua_newuserdatauv, lua_setiuservalue, and lua_getiuservalue, which have an extra argument.

For compatibility, the old names still work as macros assuming one single user value. Note, however, that userdata with zero user values are more efficient memory-wise."

The build error that I received was:

"/bin/sh ../../libtool  --tag=CC   --mode=link gcc -I../../src/lib -I../../src/lib-test -I/usr/include/lua5.2 -fPIE -DPIE -std=gnu99  -I/usr/include/tirpc -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -mfunction-return=keep -mindirect-branch=keep -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2   -pie -Wl,-z -Wl,relro -Wl,-z -Wl,now -no-undefined -Wl,--as-needed  -ltirpc  -o test-lua test_lua-test-lua.o libdovecot-lua.la ../lib-dovecot/libdovecot.la 
libtool: link: gcc -I../../src/lib -I../../src/lib-test -I/usr/include/lua5.2 -fPIE -DPIE -std=gnu99 -I/usr/include/tirpc -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -mfunction-return=keep -mindirect-branch=keep -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2 -pie -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,--as-needed -o .libs/test-lua test_lua-test-lua.o  ./.libs/libdovecot-lua.a /sources/dovecot-2.3.11.3/dovecot-2.3.11.3/src/lib-dovecot/.libs/libdovecot.so -ltirpc -llua -lm -ldl ../lib-dovecot/.libs/libdovecot.so -Wl,-rpath -Wl,/usr/lib/dovecot
/usr/bin/ld: ./.libs/libdovecot-lua.a(dlua-dovecot.o): in function `dlua_push_event':
dlua-dovecot.c:(.text+0xe62): undefined reference to `lua_newuserdata'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:559: test-lua] Error 1
make[3]: Leaving directory '/sources/dovecot-2.3.11.3/dovecot-2.3.11.3/src/lib-lua'"

I got around this error by changing lua_newuserdata to lua_newuserdatauv. The test suite passed for me as well, although I am not sure whether this will impact previous versions of Lua.