### PR TITLE
configure: Link against libunwind-generic

### DIFF
--- a/m4/want_unwind.m4
+++ b/m4/want_unwind.m4
@@ -4,9 +4,9 @@ AC_DEFUN([DOVECOT_WANT_UNWIND], [
     PKG_CHECK_EXISTS([libunwind], [
       PKG_CHECK_MODULES([LIBUNWIND], [libunwind],[
         dnl see if there is target-specific library
-        AC_CHECK_LIB([unwind-${build_cpu}], [_U${build_cpu}_init_local],[
+        PKG_CHECK_MODULES([LIBUNWIND_GENERIC], [libunwind-generic],[
           have_libunwind=yes
-          LIBUNWIND_LIBS="$LIBUNWIND_LIBS -lunwind-${build_cpu}"
+          LIBUNWIND_LIBS="$LIBUNWIND_LIBS $LIBUNWIND_GENERIC_LIBS"
           AC_DEFINE([HAVE_LIBUNWIND],,[Define this if you have libunwind])
         ],[
            have_libunwind=no


### PR DESCRIPTION
want_unwind.m4 tries to link against a ${build_cpu} specific library
that it expects to provide a ${build_cpu} specific function. On some
operating systems like HPPA2.0 that check fails. The libunwind internals
label that "hppa" whereas build_cpu is set to "hppa2.0", causing the
library check to fail:

conftest.c:167:13: error: invalid suffix "_init_local" on floating constant
  167 | char _Uhppa2.0_init_local ();
      |             ^~~~~~~~~~~~~

libunwind does however install a symbolic link for the native
architecture, which should be checked for and used instead. Confusingly,
that link is called "libunwind-generic", e.g.:

/usr/lib/libunwind-generic.so -> libunwind-hppa.so
/usr/lib/libunwind-generic.so -> libunwind-x86.so

and it installs a pkg-config file for that purpose, so use that instead.

Bug: https://bugs.gentoo.org/728336