### PR TITLE
Make metrics compliant with OpenMetrics' standards

### DIFF
--- a/src/stats/stats-service-openmetrics.c
+++ b/src/stats/stats-service-openmetrics.c
@@ -98,10 +98,10 @@ static void openmetrics_export_dovecot(string_t *out)
 {
 	i_assert(stats_startup_time <= ioloop_time);
 	str_append(out, "# HELP process_start_time_seconds "
-			"Dovecot stats service uptime\n");
+			"Timestamp of service start\n");
 	str_append(out, "# TYPE process_start_time_seconds gauge\n");
 	str_printfa(out, "process_start_time_seconds %"PRId64"\n",
-		    (int64_t)(ioloop_time - stats_startup_time));
+		    (int64_t)stats_startup_time);
 
 	str_append(out, "# HELP dovecot_build "
 			"Dovecot build information\n");

--- a/src/stats/stats-service-openmetrics.c
+++ b/src/stats/stats-service-openmetrics.c
@@ -14,7 +14,7 @@
 #include "stats-metrics.h"
 #include "stats-service-private.h"
 
-#define OPENMETRICS_CONTENT_VERSION "0.0.1"
+#define OPENMETRICS_CONTENT_VERSION "0.0.4"
 
 #ifdef DOVECOT_REVISION
 #define OPENMETRICS_BUILD_INFO \
@@ -731,7 +731,7 @@ stats_service_openmetrics_request(void *context ATTR_UNUSED,
 	hsresp = http_server_response_create(hsreq, 200, "OK");
 	http_server_response_add_header(
 		hsresp, "Content-Type",
-		"application/openmetrics-text; version="OPENMETRICS_CONTENT_VERSION"; "
+		"text/plain; version="OPENMETRICS_CONTENT_VERSION"; "
 		"charset=utf-8");
 
 	req->output = http_server_response_get_payload_output(

--- a/src/stats/stats-service-openmetrics.c
+++ b/src/stats/stats-service-openmetrics.c
@@ -14,7 +14,7 @@
 #include "stats-metrics.h"
 #include "stats-service-private.h"
 
-#define OPENMETRICS_CONTENT_VERSION "0.0.4"
+#define OPENMETRICS_CONTENT_VERSION "0.0.1"
 
 #ifdef DOVECOT_REVISION
 #define OPENMETRICS_BUILD_INFO \
@@ -731,7 +731,7 @@ stats_service_openmetrics_request(void *context ATTR_UNUSED,
 	hsresp = http_server_response_create(hsreq, 200, "OK");
 	http_server_response_add_header(
 		hsresp, "Content-Type",
-		"text/plain; version="OPENMETRICS_CONTENT_VERSION"; "
+		"application/openmetrics-text; version="OPENMETRICS_CONTENT_VERSION"; "
 		"charset=utf-8");
 
 	req->output = http_server_response_get_payload_output(

--- a/src/stats/stats-service-openmetrics.c
+++ b/src/stats/stats-service-openmetrics.c
@@ -14,7 +14,7 @@
 #include "stats-metrics.h"
 #include "stats-service-private.h"
 
-#define OPENMETRICS_CONTENT_VERSION "0.0.5"
+#define OPENMETRICS_CONTENT_VERSION "0.0.4"
 
 #ifdef DOVECOT_REVISION
 #define OPENMETRICS_BUILD_INFO \
@@ -141,8 +141,9 @@ openmetrics_export_metric_value(struct openmetrics_request *req, string_t *out,
 			    timestamp);
 		break;
 	case OPENMETRICS_METRIC_TYPE_DURATION:
+		/* Convert from us to seconds */
 		str_printfa(out, " %f %"PRId64"\n",
-			    stats_dist_get_sum(metric->duration_stats)/1000.0,
+			    stats_dist_get_sum(metric->duration_stats)/100000.0,
 			    timestamp);
 		break;
 	case OPENMETRICS_METRIC_TYPE_HISTOGRAM:
@@ -210,7 +211,8 @@ openmetrics_export_histogram(struct openmetrics_request *req, string_t *out,
 			openmetrics_find_histogram_bucket(metric, i);
 
 		if (sub_metric != NULL) {
-			sum += stats_dist_get_sum(sub_metric->duration_stats)/1000.0;
+			/* Convert from us to seconds */
+			sum += stats_dist_get_sum(sub_metric->duration_stats)/100000.0;
 			count += stats_dist_get_count(
 				sub_metric->duration_stats);
 		}
@@ -229,7 +231,7 @@ openmetrics_export_histogram(struct openmetrics_request *req, string_t *out,
 		str_append_str(out, req->labels);
 		str_append_c(out, '}');
 	}
-	str_printfa(out, " %f %"PRId64"\n", sum, timestamp);
+	str_printfa(out, " %.6f %"PRId64"\n", sum, timestamp);
 	/* Count */
 	str_append(out, "dovecot_");
 	str_append(out, metric->name);

--- a/src/stats/stats-service-openmetrics.c
+++ b/src/stats/stats-service-openmetrics.c
@@ -103,9 +103,9 @@ static void openmetrics_export_dovecot(string_t *out, int64_t timestamp)
 	str_printfa(out, "process_start_time_seconds %"PRId64" %"PRId64"\n",
 		    (int64_t)(ioloop_time - stats_startup_time), timestamp);
 
-	str_append(out, "# HELP dovecot_build_info "
+	str_append(out, "# HELP dovecot_build "
 			"Dovecot build information\n");
-	str_append(out, "# TYPE dovecot_build_info info\n");
+	str_append(out, "# TYPE dovecot_build info\n");
 	str_printfa(out, "dovecot_build_info{"OPENMETRICS_BUILD_INFO"} "
 			 "1 %"PRId64"\n", timestamp);
 }
@@ -260,10 +260,10 @@ openmetrics_export_metric_header(struct openmetrics_request *req, string_t *out)
 	str_append(out, metric->name);
 	switch (req->metric_type) {
 	case OPENMETRICS_METRIC_TYPE_COUNT:
-		str_append(out, "_total Total number of all events of this kind");
+		str_append(out, " Total number of all events of this kind");
 		break;
 	case OPENMETRICS_METRIC_TYPE_DURATION:
-		str_append(out, "_duration_seconds_total Total duration of all events of this kind");
+		str_append(out, "_duration_seconds Total duration of all events of this kind");
 		break;
 	case OPENMETRICS_METRIC_TYPE_HISTOGRAM:
 		str_append(out, " Histogram");
@@ -279,10 +279,10 @@ openmetrics_export_metric_header(struct openmetrics_request *req, string_t *out)
 	str_append(out, metric->name);
 	switch (req->metric_type) {
 	case OPENMETRICS_METRIC_TYPE_COUNT:
-		str_append(out, "_total counter\n");
+		str_append(out, " counter\n");
 		break;
 	case OPENMETRICS_METRIC_TYPE_DURATION:
-		str_append(out, "_duration_seconds_total counter\n");
+		str_append(out, "_duration_seconds counter\n");
 		break;
 	case OPENMETRICS_METRIC_TYPE_HISTOGRAM:
 		str_append(out, " histogram\n");


### PR DESCRIPTION
running `promtool check metrics` against the current metric output (2.3.11), it mentions:
```
dovecot_imap_command_count counter metrics should have "_total" suffix
dovecot_imap_command_count non-histogram and non-summary metrics should not have "_count" suffix
dovecot_imap_command_duration_usecs_sum counter metrics should have "_total" suffix
dovecot_imap_command_duration_usecs_sum non-histogram and non-summary metrics should not have "_sum" suffix
dovecot_push_notification_http_finished_count counter metrics should have "_total" suffix
dovecot_push_notification_http_finished_count non-histogram and non-summary metrics should not have "_count" suffix
dovecot_push_notification_http_finished_duration_usecs_sum counter metrics should have "_total" suffix
dovecot_push_notification_http_finished_duration_usecs_sum non-histogram and non-summary metrics should not have "_sum" suffix
dovecot_push_notifications_count counter metrics should have "_total" suffix
dovecot_push_notifications_count non-histogram and non-summary metrics should not have "_count" suffix
dovecot_push_notifications_duration_usecs_sum counter metrics should have "_total" suffix
dovecot_push_notifications_duration_usecs_sum non-histogram and non-summary metrics should not have "_sum" suffix
dovecot_stats_uptime_seconds counter metrics should have "_total" suffix
dovecot_storage_http_gets_count counter metrics should have "_total" suffix
dovecot_storage_http_gets_count non-histogram and non-summary metrics should not have "_count" suffix
dovecot_storage_http_gets_duration_usecs_sum counter metrics should have "_total" suffix
dovecot_storage_http_gets_duration_usecs_sum non-histogram and non-summary metrics should not have "_sum" suffix
```

There was also feedback from a Prometheus' developer in https://github.com/prometheus/docs/pull/1738#issuecomment-683635557

@jeffpc @sirainen 

