### PR TITLE
Portability: use `uname -n` instead of `hostname`

### DIFF
--- a/src/util/dovecot-sysreport
+++ b/src/util/dovecot-sysreport
@@ -2,7 +2,7 @@
 
 set -eu
 
-dest="dovecot-sysreport-$(hostname)-$(date +'%s').tar.gz"
+dest="dovecot-sysreport-$(uname -n)-$(date +'%s').tar.gz"
 conf_flag=""
 binary=""
 core=""


### PR DESCRIPTION
as hostname is not defined by POSIX, so not guaranteed to work:

```
$ sudo dovecot-sysreport 
/usr/bin/dovecot-sysreport: line 5: hostname: command not found
Gathering configurations ...
Gathering system informations ...
Creating archive ...
All done! Please report file dovecot-sysreport--1602270230.tar.gz
Removing temp files at /tmp/tmp.SnQRajq7tD ...
```
(notice the hostname is missing from the report filename, this is on a default Arch Linux install.)