### PR TITLE
Message-ID fails DKIM, Message-Id is better

### DIFF
--- a/src/doveadm/doveadm-mail-deduplicate.c
+++ b/src/doveadm/doveadm-mail-deduplicate.c
@@ -90,7 +90,7 @@ cmd_deduplicate_box(struct doveadm_mail_cmd_context *_ctx,
 	hash_table_create(&hash, pool, 0, str_hash, strcmp);
 	while (doveadm_mail_iter_next(iter, &mail)) {
 		if (ctx->by_msgid) {
-			if (mail_get_first_header(mail, "Message-ID", &key) < 0) {
+			if (mail_get_first_header(mail, "Message-Id", &key) < 0) {
 				errstr = mailbox_get_last_internal_error(mail->box, &error);
 				if (error == MAIL_ERROR_NOTFOUND)
 					continue;

--- a/src/lda/main.c
+++ b/src/lda/main.c
@@ -45,7 +45,7 @@ struct event_category event_category_lda = {
 };
 
 static const char *wanted_headers[] = {
-	"From", "To", "Message-ID", "Subject", "Return-Path",
+	"From", "To", "Message-Id", "Subject", "Return-Path",
 	NULL
 };
 

--- a/src/lib-lda/mail-deliver.c
+++ b/src/lib-lda/mail-deliver.c
@@ -47,7 +47,7 @@ struct mail_deliver_transaction {
 };
 
 static const char *lda_log_wanted_headers[] = {
-	"From", "Message-ID", "Subject",
+	"From", "Message-Id", "Subject",
 	NULL
 };
 static enum mail_fetch_field lda_log_wanted_fetch_fields =

--- a/src/lib-lda/mail-send.c
+++ b/src/lib-lda/mail-send.c
@@ -64,7 +64,7 @@ int mail_send_rejection(struct mail_deliver_context *ctx,
 	string_t *str;
 	int ret;
 
-	if (mail_get_first_header(mail, "Message-ID", &orig_msgid) < 0)
+	if (mail_get_first_header(mail, "Message-Id", &orig_msgid) < 0)
 		orig_msgid = NULL;
 
 	if (mail_get_first_header(mail, "Auto-Submitted", &value) > 0 &&

--- a/src/lib-mail/message-part-data.c
+++ b/src/lib-mail/message-part-data.c
@@ -13,7 +13,7 @@
 
 const char *message_part_envelope_headers[] = {
 	"Date", "Subject", "From", "Sender", "Reply-To",
-	"To", "Cc", "Bcc", "In-Reply-To", "Message-ID",
+	"To", "Cc", "Bcc", "In-Reply-To", "Message-Id",
 	NULL
 };
 

--- a/src/lib-storage/index/mbox/mbox-md5-apop3d.c
+++ b/src/lib-storage/index/mbox/mbox-md5-apop3d.c
@@ -71,7 +71,7 @@ static bool parse_x_delivery_id(struct mbox_md5_context *ctx,
 static struct mbox_md5_header_func md5_header_funcs[] = {
 	{ "Date", parse_date },
 	{ "Delivered-To", parse_delivered_to },
-	{ "Message-ID", parse_message_id },
+	{ "Message-Id", parse_message_id },
 	{ "Received", parse_received },
 	{ "X-Delivery-ID", parse_x_delivery_id }
 };

--- a/src/lib-storage/mail.c
+++ b/src/lib-storage/mail.c
@@ -370,7 +370,7 @@ int mail_get_message_id(struct mail *mail, const char **value_r)
 
 	*value_r = NULL;
 
-	ret = mail_get_first_header(mail, "Message-ID", &hdr_value);
+	ret = mail_get_first_header(mail, "Message-Id", &hdr_value);
 	if (ret <= 0)
 		return ret;
 

--- a/src/lmtp/lmtp-local.c
+++ b/src/lmtp/lmtp-local.c
@@ -698,7 +698,7 @@ lmtp_local_open_raw_mail(struct lmtp_local *local,
 			 struct istream *input)
 {
 	static const char *wanted_headers[] = {
-		"From", "To", "Message-ID", "Subject", "Return-Path",
+		"From", "To","Message-Id", "Subject", "Return-Path",
 		NULL
 	};
 	struct client *client = local->client;

--- a/src/plugins/mail-log/mail-log-plugin.c
+++ b/src/plugins/mail-log/mail-log-plugin.c
@@ -214,7 +214,7 @@ mail_log_update_wanted_fields(struct mail *mail, enum mail_log_field fields)
 	unsigned int hdr_idx = 0;
 
 	if ((fields & MAIL_LOG_FIELD_MSGID) != 0)
-		headers[hdr_idx++] = "Message-ID";
+		headers[hdr_idx++] = "Message-Id";
 	if ((fields & MAIL_LOG_FIELD_FROM) != 0)
 		headers[hdr_idx++] = "From";
 	if ((fields & MAIL_LOG_FIELD_SUBJECT) != 0)
@@ -271,7 +271,7 @@ mail_log_append_mail_message_real(struct mail_log_mail_txn_context *ctx,
 		str_append(text, ", ");
 	}
 	if ((muser->fields & MAIL_LOG_FIELD_MSGID) != 0) {
-		mail_log_append_mail_header(text, mail, "msgid", "Message-ID");
+		mail_log_append_mail_header(text, mail, "msgid", "Message-Id");
 		str_append(text, ", ");
 	}
 	if ((muser->fields & MAIL_LOG_FIELD_PSIZE) != 0) {

--- a/src/plugins/push-notification/push-notification-event-message-common.c
+++ b/src/plugins/push-notification/push-notification-event-message-common.c
@@ -92,7 +92,7 @@ void push_notification_message_fill(
 
 	if ((*message_id == NULL) &&
 	    (event_flags & PUSH_NOTIFICATION_MESSAGE_HDR_MESSAGE_ID) != 0 &&
-	    (mail_get_first_header(mail, "Message-ID", &value) >= 0)) {
+	    (mail_get_first_header(mail, "Message-Id", &value) >= 0)) {
 		*message_id = p_strdup(pool, value);
 	}
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc5321 mentions addition of a message-id.
Adding a Message-ID if missing has a side effect. Processing the message adds the missing Message-ID, but SMTP servers then add an incorrect DKIM signature, causing outlook, hotmail and yahoo (tested) to add DKIM:fail header, putting the message into Junk or Spam folder.
Adding a Message-Id rather than a Message-ID by the client or SMTP server will work around this feature.