### PR TITLE
doveadm-mail-server: configure TLS on non proxied request

### DIFF
--- a/src/doveadm/doveadm-mail-server.c
+++ b/src/doveadm/doveadm-mail-server.c
@@ -196,13 +196,13 @@ doveadm_mail_server_user_get_host(struct doveadm_mail_cmd_context *ctx,
 	*host_r = ctx->set->doveadm_socket_path;
 	*port_r = ctx->set->doveadm_port;
 
-	if (ctx->set->doveadm_port == 0)
-		return 0;
-
 	if (strcmp(ctx->set->doveadm_ssl, "ssl") == 0)
 		*ssl_flags_r |= PROXY_SSL_FLAG_YES;
 	else if (strcmp(ctx->set->doveadm_ssl, "starttls") == 0)
 		*ssl_flags_r |= PROXY_SSL_FLAG_YES | PROXY_SSL_FLAG_STARTTLS;
+
+	if (ctx->set->doveadm_port == 0)
+		return 0;
 
 	/* make sure we have an auth connection */
 	mail_storage_service_init_settings(ctx->storage_service, input);


### PR DESCRIPTION
When remotely calling doveadm through the `socket-path` argument (for example `doveadm mailbox list -u vtestuser -S ${host}:{$port}`, without doveadm_port configured (not on a proxy host), we still need to configure TLS in case the remote endpoint uses TLS.