### PR TITLE
fixed bug in ossfuzz target.

### DIFF
--- a/src/lib-mail/Makefile.am
+++ b/src/lib-mail/Makefile.am
@@ -114,7 +114,7 @@ test_programs = \
 	test-rfc2231-parser \
 	test-rfc822-parser
 
-fuzz_programs = fuzz_message_parser
+fuzz_programs = fuzz-message_parser
 
 noinst_PROGRAMS = $(fuzz_programs) $(test_programs)
 nodist_EXTRA_fuzz_message_parser_SOURCES = force-cxx-linking.cxx


### PR DESCRIPTION
a mistake which, judging by build.sh, leads to the fact that the fuzz-message_parser target was never built or executed.

```
# Copy over the fuzzers
find . -name "fuzz-*" -executable -exec cp {} $OUT/ \;
```