### PR TITLE
Fix a corruption of the envelope sender when running sieve scripts

### DIFF
--- a/src/lib-storage/index/raw/raw-storage.c
+++ b/src/lib-storage/index/raw/raw-storage.c
@@ -77,7 +77,7 @@ raw_mailbox_alloc_common(struct mail_user *user, struct istream *input,
 
 	i_assert(strcmp(box->storage->name, RAW_STORAGE_NAME) == 0);
 	raw_box = RAW_MAILBOX(box);
-	raw_box->envelope_sender = envelope_sender;
+	raw_box->envelope_sender = p_strdup(box->pool, envelope_sender);
 	raw_box->mtime = received_time;
 	return 0;
 }


### PR DESCRIPTION
Hi!

I noticed that my inbox folders in mbox format are corrupted, with garbled "From " headers added by dovecot-lda.  Sometimes, the enveloppe sender is replaced by non-printable characters. possibly containing newline, which then generate a visible error in the maillog file, like this one:

```
Jan 15 08:29:31 vm1 dovecot[349261]: lda(testuser)<349261><z6dfMlVEAWBNVAUAkSfQGw>: Error: Next message unexpectedly corrupted in mbox file /var/mail/testuser at 8761229
```
Most of the time, the garbled envelope sender remains unnoticed by the user, but running an ``egrep '^From .*[^[:print:]]' /var/spool/mail/*`` gives a good hint of the presence of the problem.

This is specific to the presence of sieve scripts in the user's home directory. I can reliably reproduce the problem, with dovecot 2.3.13 on a fedora 33 box.

After some debugging, I noticed that function ``sieve_message_substitute()`` obtains the envelope sender by calling ``smtp_address_encode(sender)``, and puts this newly allocated string pointer in ``((struct raw_mailbox *)box)->envelope_sender``.

The problem is that is pointer stops to exist very quickly, when the stack is poped in ``sieve_interpreter_operation_execute()``.

But this string is still required in later sieve scripts operations, especially in ``act_store_execute()`` line 654, with ``((struct raw_mailbox *)mail->box)->envelope_sender``

I'm not sure if duplicating the strings there, and attaching it to the mailbox memory pool is the right way to fix it, but it works for me.



