### PR TITLE
Health check shell compatibility

### DIFF
--- a/src/util/health-check.sh
+++ b/src/util/health-check.sh
@@ -7,20 +7,20 @@
 # 	executable = script -p /path/to/health-check.sh
 #
 # This simple example merely answers "PONG\n" if the input is "PING\n". It
-# stops waiting for input after $TIMEOUT which causes the process to die
+# stops waiting for input after $timeout which causes the process to die
 # which causes the script module to close the socket. Inputs and outputs
 # can be written to STDIN and STDOUT, they are duplicated file-descriptors
 # if called from the script service.
 
-TIMEOUT=10
+timeout=10
 
 # prefer read with timeout (bash, busybox sh) or fall back to POSIX read (dash)
-read -t ${TIMEOUT} -r input 2>/dev/null || read -r input
+read -t ${timeout} -r input 2>/dev/null || read -r input
 
 exit_code=$?
-cleaned_input=$(echo $input | sed "s/[^a-zA-Z0-9]//g")
+cleaned_input=$(echo ${input} | sed "s/[^a-zA-Z0-9]//g")
 
-if [ $exit_code -eq 0 ] && [ "$cleaned_input" = "PING" ];then
+if [ ${exit_code} -eq 0 ] && [ "${cleaned_input}" = "PING" ];then
 	echo "PONG"
 fi
 # always exit successful

--- a/src/util/health-check.sh
+++ b/src/util/health-check.sh
@@ -14,8 +14,13 @@
 
 timeout=10
 
-# prefer read with timeout (bash, busybox sh) or fall back to POSIX read (dash)
-read -t ${timeout} -r input 2>/dev/null || read -r input
+# timeout the read via trap for POSIX shell compatibility
+trap "exit 0" QUIT
+{
+	sleep $timeout
+	kill -3 $$ 2>/dev/null
+} &
+read -r input
 
 exit_code=$?
 cleaned_input=$(echo ${input} | sed "s/[^a-zA-Z0-9]//g")

--- a/src/util/health-check.sh
+++ b/src/util/health-check.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Copyright (c) 2019 Dovecot authors, see the included COPYING file */
 #
@@ -14,10 +14,11 @@
 
 TIMEOUT=10
 
-read -t ${TIMEOUT} -r input
+# prefer read with timeout (bash, busybox sh) or fall back to POSIX read (dash)
+read -t ${TIMEOUT} -r input 2>/dev/null || read -r input
 
 exit_code=$?
-cleaned_input=${input//[^a-zA-Z0-9]/}
+cleaned_input=$(echo $input | sed "s/[^a-zA-Z0-9]//g")
 
 if [ $exit_code -eq 0 ] && [ "$cleaned_input" = "PING" ];then
 	echo "PONG"


### PR DESCRIPTION
The below changes intend to address the following points:
- changed the script to be compatible with Debian Almquist shell (dash), allowing it to use the `#!/bin/sh` she-bang safely on a large number of Linux distros
- consistency of variable naming and usage (all upper case and with `${}` guards)

Please advise if this is an inappropriate change, needs improvement of any form or in the style of the submission.

### Motivation
Wanting to add a [health check to an Alpine Linux based container image](https://github.com/simonrupf/docker-dovecot/blob/4d49969fdfdc679459c30812c814d81518c0a9f9/Dockerfile#L14), I found the documentation on this script and how it is used. When implementing it in the image, I [changed the she-bang](https://github.com/simonrupf/docker-dovecot/blob/4d49969fdfdc679459c30812c814d81518c0a9f9/Dockerfile#L5) and found the script already working just fine with Alpine's busybox sh shell.

I considered submitting a PR with just the she-bang line changed, so that a future release of dovecot in Alpine would already include a script that works unchanged, but realized that some Linux distro's neither use bash nor busybox as `/bin/sh`. To my knowledge, at least the Debian derivatives have switched to the dash shell. Hence I started testing the script on a number of shells (see below) and included some additional changes that allow it to run an all of them.

### Testing
This change was tested using an Alpine Linux container and the following shells:
- busybox sh
- bash
- dash
- zsh

This change has **not** been tested on BSD sh (Almquist shell)! Please do advise if testing on BSD sh should be done for this be considered.

```shell
$ docker run --rm -t -v $PWD/src/util/health-check.sh:/bin/health-check:ro alpine:3.13 sh -c 'apk add bash dash zsh ; for SHELL in sh bash dash zsh ; do for INPUT in PING PENG /PING/ ; do echo -en "\n$SHELL input $INPUT: " ; echo $INPUT | $SHELL /bin/health-check ; done ; done'
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/7) Installing ncurses-terminfo-base (6.2_p20210109-r0)
(2/7) Installing ncurses-libs (6.2_p20210109-r0)
(3/7) Installing readline (8.1.0-r0)
(4/7) Installing bash (5.1.0-r0)
Executing bash-5.1.0-r0.post-install
(5/7) Installing dash (0.5.11.3-r0)
Executing dash-0.5.11.3-r0.post-install
(6/7) Installing zsh (5.8-r1)
Executing zsh-5.8-r1.post-install
(7/7) Installing apk-tools-zsh-completion (2.12.0-r4)
Executing busybox-1.32.1-r0.trigger
OK: 14 MiB in 21 packages

sh input PING: PONG

sh input PENG: 
sh input /PING/: PONG

bash input PING: PONG

bash input PENG: 
bash input /PING/: PONG

dash input PING: PONG

dash input PENG: 
dash input /PING/: PONG

zsh input PING: PONG

zsh input PENG: 
zsh input /PING/: PONG
```