### PR TITLE
allow doveadm to log into dovecot.conf configured facility (like syslog)

### DIFF
--- a/doc/man/doveadm.1.in
+++ b/doc/man/doveadm.1.in
@@ -4,7 +4,7 @@
 doveadm \- Dovecot\(aqs administration utility
 .\"------------------------------------------------------------------------
 .SH SYNOPSIS
-.BR doveadm " [" \-Dv "] [" \-f
+.BR doveadm " [" \-Dsv "] [" \-f
 .IR formatter ]
 .IR command " [" command_options "] [" command_arguments ]
 .\"------------------------------------------------------------------------

--- a/doc/man/global-options-formatter.inc
+++ b/doc/man/global-options-formatter.inc
@@ -6,6 +6,9 @@ Global
 .B \-D
 Enables verbosity and debug messages.
 .TP
+.B \-s
+Don't log to stderr and use log destination from configuration instead.
+.TP
 .BI \-f\  formatter
 Specifies the
 .I formatter

--- a/src/doveadm/doveadm.c
+++ b/src/doveadm/doveadm.c
@@ -121,7 +121,7 @@ usage_to(FILE *out, const char *prefix)
 	const struct doveadm_cmd *cmd;
 	string_t *str = t_str_new(1024);
 
-	fprintf(out, "usage: doveadm [-Dv] [-f <formatter>] ");
+	fprintf(out, "usage: doveadm [-Dsv] [-f <formatter>] ");
 	if (*prefix != '\0')
 		fprintf(out, "%s ", prefix);
 	fprintf(out, "<command> [<args>]\n");
@@ -317,7 +317,7 @@ int main(int argc, char *argv[])
 	/* "+" is GNU extension to stop at the first non-option.
 	   others just accept -+ option. */
 	master_service = master_service_init("doveadm", service_flags,
-					     &argc, &argv, "+Df:hv");
+					     &argc, &argv, "+Df:hsv");
 	while ((c = master_getopt(master_service)) > 0) {
 		switch (c) {
 		case 'D':
@@ -329,6 +329,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'h':
 			doveadm_print_hide_titles = TRUE;
+			break;
+		case 's':
+			service_flags |= MASTER_SERVICE_FLAG_DONT_LOG_TO_STDERR;
 			break;
 		case 'v':
 			doveadm_verbose = TRUE;


### PR DESCRIPTION
Add -s option that causes doveadm log into configured facility instead of stderr.

Rationale:
doveadm can be run from system scripts to do some jobs like expiring folders. Unfortunately it doesn't log anything into syslog and instead forces stderr logging.

With this change doveadm can log into logging facility configured in dovecot.conf

Example:
````
protocol doveadm {
  mail_plugins = $mail_plugins mail_log notify acl
}
plugin {
  mail_log_events = delete undelete expunge copy mailbox_delete
mailbox_rename save
}
````

and

````
$ sudo doveadm -s expunge -u arekm mailbox INBOX.Test savedbefore 0d
$ tail -n 2 /var/log/maillog
Feb 11 18:36:11 ixion dovecot[875844]: doveadm(arekm): expunge: box=INBOX.Test, uid=47, msgid=<5b2e2a9c6e2fa387a89de052259248bc@example.com>, size=4693
Feb 11 18:36:12 ixion dovecot[875864]: doveadm(arekm): expunge: box=INBOX.Test, uid=48, msgid=<4b389ac5180b609c0e4b5bdaac76793e@example.coml>, size=5162
````
