### PR TITLE
stats: Change histogram threshold unit to seconds

### DIFF
--- a/src/stats/stats-service-openmetrics.c
+++ b/src/stats/stats-service-openmetrics.c
@@ -196,10 +196,12 @@ openmetrics_export_histogram_bucket(struct openmetrics_request *req,
 		str_append_str(out, req->labels);
 		str_append_c(out, ',');
 	}
-	if (bucket_limit == INTMAX_MAX)
+	if (bucket_limit == INTMAX_MAX) {
 		str_append(out, "le=\"+Inf\"");
-	else
-		str_printfa(out, "le=\"%jd\"", bucket_limit);
+	} else {
+		/* Convert from microseconds to seconds */
+		str_printfa(out, "le=\"%.6f\"", bucket_limit/1e6F);
+	}
 	str_printfa(out, "} %"PRIu64"\n", count);
 }
 


### PR DESCRIPTION
In #136 the unit of durations was changed from microseconds to seconds, but the `le` field in histograms is still in microseconds.

This applies the same division by `1e6F` to the histograms threshold, to convert from microseconds to seconds.