### PR TITLE
Fix fts-solr

### DIFF
--- a/src/plugins/fts-solr/fts-backend-solr-old.c
+++ b/src/plugins/fts-solr/fts-backend-solr-old.c
@@ -710,7 +710,7 @@ fts_backend_solr_lookup(struct fts_backend *_backend, struct mailbox *box,
 
 	str = t_str_new(256);
 	str_printfa(str, "fl=uid,score&rows=%u&sort=uid+asc&q=%%7b!lucene+q.op%%3dAND%%7d",
-		    status.uidnext);
+		    status.messages);
 
 	if (!solr_add_definite_query_args(str, args, and_args)) {
 		/* can't search this query */

--- a/src/plugins/fts-solr/fts-backend-solr-old.c
+++ b/src/plugins/fts-solr/fts-backend-solr-old.c
@@ -705,7 +705,7 @@ fts_backend_solr_lookup(struct fts_backend *_backend, struct mailbox *box,
 	int ret;
 
 	fts_solr_set_default_ns(backend);
-	mailbox_get_open_status(box, STATUS_UIDVALIDITY | STATUS_UIDNEXT,
+	mailbox_get_open_status(box, STATUS_UIDVALIDITY | STATUS_MESSAGES,
 				&status);
 
 	str = t_str_new(256);

--- a/src/plugins/fts-solr/fts-backend-solr.c
+++ b/src/plugins/fts-solr/fts-backend-solr.c
@@ -839,7 +839,7 @@ fts_backend_solr_lookup(struct fts_backend *_backend, struct mailbox *box,
 
 	str = t_str_new(256);
 	str_printfa(str, "wt=xml&fl=uid,score&rows=%u&sort=uid+asc&q=%%7b!lucene+q.op%%3dAND%%7d",
-		    status.uidnext);
+		    status.messages);
 	prefix_len = str_len(str);
 
 	if (solr_add_definite_query_args(str, args, and_args)) {

--- a/src/plugins/fts-solr/fts-backend-solr.c
+++ b/src/plugins/fts-solr/fts-backend-solr.c
@@ -835,7 +835,7 @@ fts_backend_solr_lookup(struct fts_backend *_backend, struct mailbox *box,
 
 	if (fts_mailbox_get_guid(box, &box_guid) < 0)
 		return -1;
-	mailbox_get_open_status(box, STATUS_UIDNEXT, &status);
+	mailbox_get_open_status(box, STATUS_MESSAGES, &status);
 
 	str = t_str_new(256);
 	str_printfa(str, "wt=xml&fl=uid,score&rows=%u&sort=uid+asc&q=%%7b!lucene+q.op%%3dAND%%7d",


### PR DESCRIPTION
Send status.messages instead of status.uidnext as rows param to solr.
status.uidnext can return value above int range which rise error 400 - bad request.
Rows parameter control amount of results returned for query, and there is no need to return more results than messages on mailbox.
