### PR TITLE
doc/openssl.cnf: Increase default_bits to 2048

### DIFF
--- a/doc/dovecot-openssl.cnf
+++ b/doc/dovecot-openssl.cnf
@@ -1,5 +1,5 @@
 [ req ]
-default_bits = 1024
+default_bits = 2048
 encrypt_key = yes
 distinguished_name = req_dn
 x509_extensions = cert_type


### PR DESCRIPTION
NIST guidelines mandate that all SSL certificates must be of at least 2048 key length