### PR TITLE
imap: imap-sync - Fix VANISHED response with UID=1

### DIFF
--- a/src/imap/imap-sync.c
+++ b/src/imap/imap-sync.c
@@ -430,7 +430,7 @@ static void imap_sync_vanished(struct imap_sync_context *ctx)
 		start_uid = 0; prev_uid = 0;
 		for (seq = seqs[i].seq1; seq <= seqs[i].seq2; seq++) {
 			mail_set_seq(ctx->mail, seq);
-			if (prev_uid != ctx->mail->uid - 1) {
+			if (prev_uid == 0 || prev_uid + 1 != ctx->mail->uid) {
 				if (start_uid != 0) {
 					if (!comma)
 						comma = TRUE;


### PR DESCRIPTION
Fixes a bug introduced in `4eb3f6f27`, where a UID EXPUNGE 1 command
resulted in a VANSIHED 0:1 response, which is invalid IMAP syntax
(sequence sets must have nonzero values).

The change of `4eb3f6f27` was:

```diff
-               start_uid = 0; prev_uid = (uint32_t)-1;
+               start_uid = 0; prev_uid = 0;
                for (seq = seqs[i].seq1; seq <= seqs[i].seq2; seq++) {
                        mail_set_seq(ctx->mail, seq);
-                       if (prev_uid + 1 != ctx->mail->uid) {
+                       if (prev_uid != ctx->mail->uid - 1) {
```

Notice the second change is mathematically identical, but the first is not.  The effect is that the `if` clause previously executed every first iteration, but after the change, it would miss that first iteration whenever `ctx->mail->uid` was 1.

The fix is just to explicitly include the `prev_uid == 0` case, which make the intended execution clearer anyway.