### PR TITLE
New setting in auth_passdb allows to disable the master user for proxied connections

### DIFF
--- a/src/auth/auth-request-handler.c
+++ b/src/auth/auth-request-handler.c
@@ -205,7 +205,7 @@ auth_str_append_extra_fields(struct auth_request *request, string_t *dest)
 		}
 		if (fields->master_user != NULL &&
 		    !auth_fields_exists(fields->extra_fields, "master") &&
-            request->passdb->set->master_proxy) {
+		    request->passdb->set->master_proxy) {
 			/* the master username needs to be forwarded */
 			auth_str_add_keyvalue(dest, "master",
 					      fields->master_user);

--- a/src/auth/auth-request-handler.c
+++ b/src/auth/auth-request-handler.c
@@ -204,7 +204,8 @@ auth_str_append_extra_fields(struct auth_request *request, string_t *dest)
 					      request->mech_password);
 		}
 		if (fields->master_user != NULL &&
-		    !auth_fields_exists(fields->extra_fields, "master")) {
+		    !auth_fields_exists(fields->extra_fields, "master") &&
+            request->passdb->set->master_proxy) {
 			/* the master username needs to be forwarded */
 			auth_str_add_keyvalue(dest, "master",
 					      fields->master_user);

--- a/src/auth/auth-settings.c
+++ b/src/auth/auth-settings.c
@@ -124,6 +124,7 @@ static const struct setting_define auth_passdb_setting_defines[] = {
 	DEF(BOOL, deny),
 	DEF(BOOL, pass),
 	DEF(BOOL, master),
+	DEF(BOOL, master_proxy),
 	DEF(ENUM, auth_verbose),
 
 	SETTING_DEFINE_LIST_END
@@ -146,6 +147,7 @@ static const struct auth_passdb_settings auth_passdb_default_settings = {
 	.deny = FALSE,
 	.pass = FALSE,
 	.master = FALSE,
+	.master_proxy = TRUE,
 	.auth_verbose = "default:yes:no"
 };
 

--- a/src/auth/auth-settings.h
+++ b/src/auth/auth-settings.h
@@ -20,6 +20,7 @@ struct auth_passdb_settings {
 	bool deny;
 	bool pass; /* deprecated, use result_success=continue instead */
 	bool master;
+	bool master_proxy;
 	const char *auth_verbose;
 };
 

--- a/src/auth/test-mock.c
+++ b/src/auth/test-mock.c
@@ -88,7 +88,7 @@ void passdb_mock_mod_init(void)
 		.deny = FALSE,
 		.pass = FALSE,
 		.master = FALSE,
-	    .master_proxy = TRUE,
+		.master = TRUE,
 		.auth_verbose = "default"
 	};
 	mock_passdb_mod = passdb_preinit(mock_pool, &set);

--- a/src/auth/test-mock.c
+++ b/src/auth/test-mock.c
@@ -58,6 +58,7 @@ struct auth_passdb_settings mock_passdb_set = {
 	.deny = FALSE,
 	.pass = FALSE,
 	.master = FALSE,
+	.master_proxy = TRUE,
 	.auth_verbose = "default"
 };
 
@@ -87,6 +88,7 @@ void passdb_mock_mod_init(void)
 		.deny = FALSE,
 		.pass = FALSE,
 		.master = FALSE,
+	    .master_proxy = TRUE,
 		.auth_verbose = "default"
 	};
 	mock_passdb_mod = passdb_preinit(mock_pool, &set);


### PR DESCRIPTION
In my case dovecot director needs to connect to an IMAP proxy (perdition) which is not able to interpret the "dovecot master user field" when sent via authentication mechanism imap-login, therefore login fails when the master field is present. As I was not able to get around this setting because there seems to be no possibility to drop the master field when proxying connections I tried to introduce this new setting.

Error message from the remote proxy when the master field is present:
`May 20 05:50:30 testbox dovecot: imap-login: proxy(testuser,10.10.10.1:993): Login failed as user testuser (master masteruser): AUTHENTICATE mechanism not supported, mate: user=<testuser>, method=PLAIN, rip=::1, lip=::1, secured, session=<nfo02LrCbIQAAAAAAAAAAAAAAAAAAAAB>`

The connection here was established to localhost (dovecot director) which has the following passdb setup:
```  
passdb {  
    driver = static  
    args = nopassword=y ssl=any-cert  
    default_fields = proxy=y host=10.10.10.1  
    override_fields =  
    master_proxy = no  
    deny = no  
    master = no  
    pass = no  
    skip = never  
    mechanisms =  
    username_filter =  
    #result_failure = continue  
    #result_internalfail = continue  
    #result_success = return-ok  
  }
