### PR TITLE
lib-oauth2-jwt: Remove 'nbf < iat' check

### DIFF
--- a/src/lib-oauth2/oauth2-jwt.c
+++ b/src/lib-oauth2/oauth2-jwt.c
@@ -360,8 +360,7 @@ oauth2_jwt_body_process(const struct oauth2_settings *set, const char *alg,
 	}
 
 	/* ensure token dates are not conflicting */
-	if (nbf < iat ||
-	    exp < iat ||
+	if (exp < iat ||
 	    exp < nbf) {
 		*error_r = "Token time values are conflicting";
 		return -1;


### PR DESCRIPTION
Dovecot's OAuth2 authentication with local JWT validation contains a check making sure that the `nbf` (valid not before) timestamp does not lie in the past of the `iat` (issued at) timestamp. Otherwise the token is rejected and authentication fails.

However:
- RFC7519 does not mandate any temporal order between these two fields
- It's not uncommon to predate the `nbf` field to account for clock skew.
- Today I've encountered an auth server that predates the `nbf` field by a few minutes. Consequently, Dovecot rejects all tokens issued by this server.

This PR removes this check, as it does not seem to fulfill any purpose other than making Dovecot reject some valid tokens.