### PR TITLE
Add new oauth2 passdb config option 'assume_jwt'

### DIFF
--- a/src/auth/db-oauth2.c
+++ b/src/auth/db-oauth2.c
@@ -85,6 +85,8 @@ struct passdb_oauth2_settings {
 	/* Should we send service and local/remote endpoints as X-Dovecot-Auth headers */
 	bool send_auth_headers;
 	bool use_grant_password;
+	/* JWT tokens: If "typ" is missing from header, assume it is a JWT */
+	bool assume_jwt;
 };
 
 struct db_oauth2 {
@@ -136,6 +138,7 @@ static struct setting_def setting_defs[] = {
 	DEF_INT(max_pipelined_requests),
 	DEF_BOOL(send_auth_headers),
 	DEF_BOOL(use_grant_password),
+	DEF_BOOL(assume_jwt),
 
 	DEF_STR(tls_ca_cert_file),
 	DEF_STR(tls_ca_cert_dir),
@@ -181,6 +184,7 @@ static struct passdb_oauth2_settings default_oauth2_settings = {
 	.tls_allow_invalid_cert = FALSE,
 	.send_auth_headers = FALSE,
 	.use_grant_password = FALSE,
+	.assume_jwt = FALSE,
 	.debug = FALSE,
 };
 
@@ -266,6 +270,7 @@ struct db_oauth2 *db_oauth2_init(const char *config_path)
 	db->oauth2_set.timeout_msecs = db->set.timeout_msecs;
 	db->oauth2_set.send_auth_headers = db->set.send_auth_headers;
 	db->oauth2_set.use_grant_password = db->set.use_grant_password;
+	db->oauth2_set.assume_jwt = db->set.assume_jwt;
 	db->oauth2_set.scope = db->set.scope;
 
 	if (*db->set.active_attribute != '\0' &&

--- a/src/lib-oauth2/oauth2.h
+++ b/src/lib-oauth2/oauth2.h
@@ -50,6 +50,8 @@ struct oauth2_settings {
 	bool send_auth_headers;
 	/* Should use grant password mechanism for authentication */
 	bool use_grant_password;
+	/* JWT tokens: If "typ" is missing from header, assume it is a JWT */
+	bool assume_jwt;
 };
 
 


### PR DESCRIPTION
Dovecot's OAuth2 authentication with local JWT validation contains a check making sure that the JWT header field `typ` is present and is exactly `JWT`. However, despite most implementations setting this field, it is actually optional ([RFC 7519 Section 5.1](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1)).

Even though quite uncommon, today I've encountered an auth server that does not set the `typ` header. Consequently, Dovecot rejects all tokens issued by this server.

This PR proposes a new boolean config option for the oauth2 passdb driver backend config: `assume_jwt`
- If `false` (default), the behavior is unchanged, tokens with a missing `typ` header are rejected.
- If `true`, tokens with a missing `typ` header are assumed to be JWT. Tokens with a `typ` other than `JWT` are still rejected though.

I've chosen this approach since it does not introduce any unexpected default behavior, and still respects the `typ` header if present.  "Unexpected behavior" since there could be edge cases where setting this option to `true` could break something. I'm thinking of opaque token implementations that utilize JOSE headers, and thus may look like JWTs on coarse inspection. So this option should only be set to `true` if no such conflicting tokens are to be expected.