### PR TITLE
Support building without Lua (the default)

### DIFF
--- a/src/lib-dict/Makefile.am
+++ b/src/lib-dict/Makefile.am
@@ -1,6 +1,5 @@
 noinst_LTLIBRARIES = \
-	libdict.la \
-	libdict_lua.la
+	libdict.la
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/lib \
@@ -27,6 +26,9 @@ headers = \
 	dict-transaction-memory.h
 
 if HAVE_LUA
+noinst_LTLIBRARIES += \
+	libdict_lua.la
+
 libdict_lua_la_SOURCES =
 
 # Internally, the dict methods yield via lua_yieldk() as implemented in Lua


### PR DESCRIPTION
Building dovecot 2.3.15 failed on src/lib-dict's test-dict-client with:
gcc: error: ./.libs/libdict_lua.a: No such file or directory
As the code was building without Lua support but including a Lua variant of the libdict library unconditionally.

This problem did not occur in 2.3.14, but I have not tested 2.3.14.1
It was introduced with 1e67b93cc9f469bb144fc890a6cb9b9b9cd20811