### PR TITLE
Update stats sample config with actually useful default

### DIFF
--- a/doc/example-config/conf.d/10-metrics.conf
+++ b/doc/example-config/conf.d/10-metrics.conf
@@ -36,6 +36,57 @@
 #  filter = event=mail_delivery_finished
 #  group_by = duration:exponential:1:5:10
 #}
+#
+#metric push_notifications {
+#  filter = event=push_notification_finished
+#}
+
+#metric auth_client_userdb_lookup {
+# filter = event=auth_client_userdb_lookup_finished
+#}
+#
+#metric auth_client_passdb_lookup {
+# filter = event=auth_client_passdb_lookup_finished
+#}
+#
+#metric auth_master_client_login {
+# filter = event=auth_master_client_login_finished
+#}
+#
+#metric client_connection {
+# filter = event=client_connection_finished
+#}
+#
+#metric client_connection_connected {
+# filter = event=client_connection_connected
+#}
+#
+#metric client_connection_disconnected {
+# filter = event=client_connection_disconnected
+#}
+#
+#metric mail_index_created {
+# filter = event=mail_index_recreated
+# group_by = reason
+#}
+#
+#metric http_server_request {
+# filter = event=http_server_request_finished
+# group_by = status_code
+#}
+#
+#metric mail_delivery {
+# filter = event=mail_delivery_finished
+#}
+#
+#metric dns_request {
+# filter = event=dns_request_finished
+#}
+#
+#metric sql_query {
+# filter = event=sql_query_finished
+#}
+
 
 ##
 ## Prometheus
@@ -49,6 +100,7 @@
 
 #service stats {
 #  inet_listener http {
+#    address = 127.0.0.1
 #    port = 9900
 #  }
 #}


### PR DESCRIPTION
It is not clear to me whether it is intentional that you distribute default config with a non-functional stats module. 
These are some basic default metrics for (openmetrics compatible) monitoring. Still I need to print all the old metrics and try to find new equivalents. (Observation: _everyone_ on the net, in tutorials and guides use the _old metrics_ due to missing equivalent config. I haven't found _one_ new config example in a half hour search session. Looks disappointing.)

Also included `address = 127.0.0.1` in the example, either to show its usage or to provide a safer default.