### PR TITLE
fix panic in mbox_sync_headers_add_space on 32bit architectures

### DIFF
--- a/src/lib-storage/index/mbox/mbox-sync-rewrite.c
+++ b/src/lib-storage/index/mbox/mbox-sync-rewrite.c
@@ -93,7 +93,7 @@ static int mbox_fill_space(struct mbox_sync_context *sync_ctx,
 void mbox_sync_headers_add_space(struct mbox_sync_mail_context *ctx,
 				 size_t size)
 {
-	off_t data_size, pos, start_pos;
+	uoff_t data_size, pos, start_pos;
 	const unsigned char *data;
 	void *p;
 
@@ -105,6 +105,7 @@ void mbox_sync_headers_add_space(struct mbox_sync_mail_context *ctx,
 		/* update the header using the existing offset.
 		   otherwise we might chose wrong header and just decrease
 		   the available space */
+		i_assert(ctx->mail.offset >= ctx->hdr_offset);
 		start_pos = ctx->mail.offset - ctx->hdr_offset;
 	} else {
 		/* Append at the end of X-Keywords header,
@@ -150,7 +151,7 @@ static void mbox_sync_header_remove_space(struct mbox_sync_mail_context *ctx,
 					  size_t start_pos, size_t *size)
 {
 	const unsigned char *data;
-	off_t data_size, pos, last_line_pos;
+	uoff_t data_size, pos, last_line_pos;
 
 	/* find the end of the LWSP */
 	data = str_data(ctx->header);

--- a/src/lib-storage/index/mbox/mbox-sync-rewrite.c
+++ b/src/lib-storage/index/mbox/mbox-sync-rewrite.c
@@ -93,7 +93,7 @@ static int mbox_fill_space(struct mbox_sync_context *sync_ctx,
 void mbox_sync_headers_add_space(struct mbox_sync_mail_context *ctx,
 				 size_t size)
 {
-	size_t data_size, pos, start_pos;
+	off_t data_size, pos, start_pos;
 	const unsigned char *data;
 	void *p;
 
@@ -150,7 +150,7 @@ static void mbox_sync_header_remove_space(struct mbox_sync_mail_context *ctx,
 					  size_t start_pos, size_t *size)
 {
 	const unsigned char *data;
-	size_t data_size, pos, last_line_pos;
+	off_t data_size, pos, last_line_pos;
 
 	/* find the end of the LWSP */
 	data = str_data(ctx->header);


### PR DESCRIPTION
with dovecot dovecot-2.3.15 and dovecot-2.3.17,
the imap process dies when switching folders with:

dovecot[14023]: imap(user1)<30453><+AdUn6TSe9jAqAoq>: Panic: file mbox-sync-rewrite.c: line 119 (mbox_sync_headers_add_space): assertion failed: (start_pos < data_size)

Enviroment: FreeBSD 12.2 i386, mbox storage
The mbox file in questions is > 2GB.

I fixed the problem by replacing the 32bit "size_t" with "off_t" in mbox-sync-rewrite.c

Please add the patch below to the next release.
