### PR TITLE
Add link to the SASL GSSAPI spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Auth
 - [RFC2595 - Using TLS with IMAP, POP3 and ACAP](https://tools.ietf.org/html/rfc2595)
 - [RFC2831 - Using Digest Authentication as a SASL Mechanism (DIGEST-MD5)](https://tools.ietf.org/html/rfc2831)
 - [RFC5802 - Salted Challenge Response Authentication Mechanism (SCRAM)](https://tools.ietf.org/html/rfc5802)
-- SASL and GSS-API Mechanisms 
+- [RFC4752 - GSS-API (Kerberos V5) SASL Mechanism](https://tools.ietf.org/doc/html/rfc4752)
 - [RFC7628 - A Set of Simple Authentication and Security Layer (SASL) Mechanisms for OAuth](https://tools.ietf.org/html/rfc7628)
 - [Google XOAUTH2 protocol](https://developers.google.com/gmail/xoauth2_protocol)
 


### PR DESCRIPTION
Add link to the SASL GSSAPI spec.

(recreated from #176 per request)
