### PR TITLE
Allow child processes to setgroups() on SmartOS LX

### DIFF
--- a/src/master/capabilities-posix.c
+++ b/src/master/capabilities-posix.c
@@ -28,6 +28,8 @@ void drop_capabilities(void)
 		     N_ELEMENTS(suidcaps), suidcaps, CAP_SET);
 	cap_set_flag(caps, CAP_EFFECTIVE,
 		     N_ELEMENTS(suidcaps), suidcaps, CAP_SET);
+	cap_set_flag(caps, CAP_INHERITABLE,
+		     N_ELEMENTS(suidcaps), suidcaps, CAP_SET);
 	cap_set_proc(caps);
 	cap_free(caps);
 }


### PR DESCRIPTION
I'm trying to run Dovecot 2.3.19 (RPM from repo.dovecot.org) in CentOS Stream 8, running in a SmartOS LX zone (an Illumos kernel with a Linux syscall emulation layer).

When I launch Dovecot, it emits this message:
```
log(…): Fatal: setgroups() failed: Operation not permitted
```

If I understand correctly, the following sequence of events leads to that error:

   1. `master/main.c` calls `drop_capabilities()`, which updates the `master` process to have only certain Permitted and Effective capabilities, and no Inheritable capabilities
   2. `master/main.c` forks and execs the `log` process
   3. `log/main.c` calls `restrict_access_by_env()`, which calls `restrict_access()`, which calls `fix_groups_list()`, which calls `setgroups()`
   4. `setgroups()` fails because the `log` process does not have the `CAP_SETGID` capability (or any capabilities, for that matter), because in step 1 the `master` process specified no Inheritable capabilities

Therefore I think the solution is to have `drop_capabilities()` also specify Inheritable capabilities.

## Test
### ❌ `dovecot-2.3.19-2.x86_64.rpm` from repo.dovecot.org
```console
# uname -a
Linux localhost 3.13.0 BrandZ virtual linux x86_64 x86_64 x86_64 GNU/Linux
# cat /etc/system-release
CentOS Stream release 8
# /usr/sbin/dovecot -F
May 12 19:42:03 master: Info: Dovecot v2.3.19 (b3ad6004dc) starting up for imap, pop3, lmtp (core dumps disabled)
May 12 19:42:03 log(96325): Fatal: setgroups() failed: Operation not permitted
May 12 19:42:03 master: Error: service(log): child 96325 returned error 89 (Fatal failure)
May 12 19:42:03 master: Error: service(log): command startup failed, throttling for 2.000 secs
May 12 19:42:03 master: Error: service(config): command startup failed, throttling for 2.000 secs
May 12 19:42:03 master: Error: service(anvil): command startup failed, throttling for 2.000 secs
May 12 19:42:08 master: Error: service(config): command startup failed, throttling for 4.000 secs
May 12 19:42:08 master: Error: service(stats): command startup failed, throttling for 2.000 secs
May 12 19:42:12 master: Error: service(config): command startup failed, throttling for 8.000 secs
May 12 19:42:12 master: Error: service(imap-login): command startup failed, throttling for 2.000 secs

# # from another terminal:
# nc 10.0.42.6 143 < /dev/null
# # (no output)
```
### ✅ Local build with this MR
```console
# /opt/dovecot/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
May 12 19:43:08 master: Info: Dovecot v0.0.0-30709+7e36988a4f-dirty (7e36988a4f) starting up for imap, pop3, lmtp (core dumps disabled)
May 12 19:43:16 imap-login: Info: Disconnected: Connection closed (no auth attempts in 0 secs): user=<>, rip=10.0.43.2, lip=10.0.42.6, session=<qsAvH9neG9MKACsC>

# # from another terminal:
# nc 10.0.42.6 143 < /dev/null
* OK [CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+ STARTTLS LOGINDISABLED] Dovecot ready.
```
