### PR TITLE
lib-index: Fix overlinking

### DIFF
--- a/src/lib-index/Makefile.am
+++ b/src/lib-index/Makefile.am
@@ -1,9 +1,19 @@
-noinst_LTLIBRARIES = libindex.la
+index_libs = \
+	libmail-index-transaction-finish.la \
+	libmail-index-transaction-update.la \
+	libmail-index-util.la \
+	libmail-index-write.la \
+	libmail-transaction-log-append.la \
+	libmail-transaction-log-view.la
+
+noinst_LTLIBRARIES = libindex.la $(index_libs)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/lib \
 	-I$(top_srcdir)/src/lib-test \
 	-I$(top_srcdir)/src/lib-mail
+
+AM_LDFLAGS = -no-undefined
 
 libindex_la_SOURCES = \
 	mail-cache.c \
@@ -24,25 +34,39 @@ libindex_la_SOURCES = \
         mail-index-modseq.c \
         mail-index-transaction.c \
         mail-index-transaction-export.c \
-        mail-index-transaction-finish.c \
         mail-index-transaction-sort-appends.c \
-        mail-index-transaction-update.c \
         mail-index-transaction-view.c \
         mail-index-strmap.c \
         mail-index-sync.c \
         mail-index-sync-ext.c \
         mail-index-sync-keywords.c \
         mail-index-sync-update.c \
-        mail-index-util.c \
         mail-index-view.c \
         mail-index-view-sync.c \
-        mail-index-write.c \
         mail-transaction-log.c \
-        mail-transaction-log-append.c \
         mail-transaction-log-file.c \
         mail-transaction-log-modseq.c \
-        mail-transaction-log-view.c \
         mailbox-log.c
+
+libindex_la_LIBADD = $(index_libs)
+
+libmail_index_transaction_finish_la_SOURCES = \
+	mail-index-transaction-finish.c
+
+libmail_index_transaction_update_la_SOURCES = \
+	mail-index-transaction-update.c
+
+libmail_index_util_la_SOURCES = \
+	mail-index-util.c
+
+libmail_index_write_la_SOURCES = \
+	mail-index-write.c
+
+libmail_transaction_log_append_la_SOURCES = \
+	mail-transaction-log-append.c
+
+libmail_transaction_log_view_la_SOURCES = \
+	mail-transaction-log-view.c
 
 headers = \
 	mail-cache.h \
@@ -79,63 +103,48 @@ test_programs = \
 noinst_PROGRAMS = $(test_programs)
 
 test_libs = \
-	mail-index-util.lo \
+	libmail-index-util.la \
 	../lib-test/libtest.la \
 	../lib/liblib.la
 
-test_deps = $(noinst_LTLIBRARIES) $(test_libs)
-
 test_mail_cache_SOURCES = test-mail-cache-common.c test-mail-cache.c
-test_mail_cache_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_cache_DEPENDENCIES = $(test_deps)
+test_mail_cache_LDADD = libindex.la $(test_libs)
 
 test_mail_cache_fields_SOURCES = test-mail-cache-common.c test-mail-cache-fields.c
-test_mail_cache_fields_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_cache_fields_DEPENDENCIES = $(test_deps)
+test_mail_cache_fields_LDADD = libindex.la $(test_libs)
 
 test_mail_cache_purge_SOURCES = test-mail-cache-common.c test-mail-cache-purge.c
-test_mail_cache_purge_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_cache_purge_DEPENDENCIES = $(test_deps)
+test_mail_cache_purge_LDADD = libindex.la $(test_libs)
 
 test_mail_index_SOURCES = test-mail-index.c
-test_mail_index_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_index_DEPENDENCIES = $(test_deps)
+test_mail_index_LDADD = libindex.la $(test_libs)
 
 test_mail_index_map_SOURCES = test-mail-index-map.c
-test_mail_index_map_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_index_map_DEPENDENCIES = $(test_deps)
+test_mail_index_map_LDADD = libindex.la $(test_libs)
 
 test_mail_index_modseq_SOURCES = test-mail-index-modseq.c
-test_mail_index_modseq_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_index_modseq_DEPENDENCIES = $(test_deps)
+test_mail_index_modseq_LDADD = libindex.la $(test_libs)
 
 test_mail_index_sync_ext_SOURCES = test-mail-index-sync-ext.c
-test_mail_index_sync_ext_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_index_sync_ext_DEPENDENCIES = $(test_deps)
+test_mail_index_sync_ext_LDADD = libindex.la $(test_libs)
 
 test_mail_index_transaction_finish_SOURCES = test-mail-index-transaction-finish.c
-test_mail_index_transaction_finish_LDADD = mail-index-transaction-finish.lo $(test_libs)
-test_mail_index_transaction_finish_DEPENDENCIES = $(test_deps)
+test_mail_index_transaction_finish_LDADD = libmail-index-transaction-finish.la $(test_libs)
 
 test_mail_index_transaction_update_SOURCES = test-mail-index-transaction-update.c
-test_mail_index_transaction_update_LDADD = mail-index-transaction-update.lo $(test_libs)
-test_mail_index_transaction_update_DEPENDENCIES = $(test_deps)
+test_mail_index_transaction_update_LDADD = libmail-index-transaction-update.la $(test_libs)
 
 test_mail_index_write_SOURCES = test-mail-index-write.c
-test_mail_index_write_LDADD = mail-index-write.lo $(test_libs)
-test_mail_index_write_DEPENDENCIES = $(test_deps)
+test_mail_index_write_LDADD = libmail-index-write.la $(test_libs)
 
 test_mail_transaction_log_append_SOURCES = test-mail-transaction-log-append.c
-test_mail_transaction_log_append_LDADD = mail-transaction-log-append.lo $(test_libs)
-test_mail_transaction_log_append_DEPENDENCIES = $(test_deps)
+test_mail_transaction_log_append_LDADD = libmail-transaction-log-append.la $(test_libs)
 
 test_mail_transaction_log_file_SOURCES = test-mail-transaction-log-file.c
-test_mail_transaction_log_file_LDADD = $(noinst_LTLIBRARIES) $(test_libs)
-test_mail_transaction_log_file_DEPENDENCIES = $(test_deps)
+test_mail_transaction_log_file_LDADD = libindex.la $(test_libs)
 
 test_mail_transaction_log_view_SOURCES = test-mail-transaction-log-view.c
-test_mail_transaction_log_view_LDADD = mail-transaction-log-view.lo $(test_libs)
-test_mail_transaction_log_view_DEPENDENCIES = $(test_deps)
+test_mail_transaction_log_view_LDADD = libmail-transaction-log-view.la $(test_libs)
 
 check-local:
 	for bin in $(test_programs); do \


### PR DESCRIPTION
When building dovecot with slibtool the build will fail with several multiple definition errors.

This happens because the lib-index/Makefile.am links the tests with both the libtool archives (.la) and libtool objects (.lo) that already exist in the .la files.

GNU libtool does some magic to silently hide the issue while slibtool explicitly does as its told which is where the bug is then exposed.

This can be solved by better sorting individual files into their own convenience libraries to be used by both libindex.la and the tests as needed. This also allows removing the many _DEPENDENCIES lines as they are now redundant.

Gentoo Bug: https://bugs.gentoo.org/782631
```
rdlibtool --tag=CC --mode=link gcc -std=gnu99 -g -O2 -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -mfunction-return=keep -mindirect-branch=keep -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2 -no-undefined -Wl,--as-needed -o test-mail-cache test-mail-cache-common.o test-mail-cache.o libindex.la mail-index-util.lo ../lib-test/libtest.la ../lib/liblib.la

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/dovecot/src/lib-index"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 1311334}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 1310559}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(3,"../",O_DIRECTORY,0) = 4.
rdlibtool: lconf: fstat(4,...) = 0 {.st_dev = 45, .st_ino = 1310254}.
rdlibtool: lconf: openat(4,"libtool",O_RDONLY,0) = 3.
rdlibtool: lconf: found "/tmp/dovecot/libtool".
rdlibtool: link: gcc test-mail-cache-common.o test-mail-cache.o .libs/libindex.a .libs/mail-index-util.o ../lib-test/.libs/libtest.a ../lib/.libs/liblib.a -std=gnu99 -g -O2 -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -mfunction-return=keep -mindirect-branch=keep -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2 -Wl,--as-needed -L.libs -lunwind-generic -lunwind -Wl,--no-undefined -o .libs/test-mail-cache
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/mail-index-util.o: in function `mail_index_uint32_to_offset':
/tmp/dovecot/src/lib-index/mail-index-util.c:9: multiple definition of `mail_index_uint32_to_offset'; .libs/libindex.a(mail-index-util.o):/tmp/dovecot/src/lib-index/mail-index-util.c:9: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/mail-index-util.o: in function `mail_index_offset_to_uint32':
/tmp/dovecot/src/lib-index/mail-index-util.c:24: multiple definition of `mail_index_offset_to_uint32'; .libs/libindex.a(mail-index-util.o):/tmp/dovecot/src/lib-index/mail-index-util.c:24: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/mail-index-util.o: in function `mail_index_pack_num':
/tmp/dovecot/src/lib-index/mail-index-util.c:44: multiple definition of `mail_index_pack_num'; .libs/libindex.a(mail-index-util.o):/tmp/dovecot/src/lib-index/mail-index-util.c:44: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/mail-index-util.o: in function `mail_index_unpack_num':
/tmp/dovecot/src/lib-index/mail-index-util.c:51: multiple definition of `mail_index_unpack_num'; .libs/libindex.a(mail-index-util.o):/tmp/dovecot/src/lib-index/mail-index-util.c:51: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/mail-index-util.o: in function `mail_index_seq_array_lookup':
/tmp/dovecot/src/lib-index/mail-index-util.c:90: multiple definition of `mail_index_seq_array_lookup'; .libs/libindex.a(mail-index-util.o):/tmp/dovecot/src/lib-index/mail-index-util.c:90: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/mail-index-util.o: in function `mail_index_seq_array_alloc':
/tmp/dovecot/src/lib-index/mail-index-util.c:97: multiple definition of `mail_index_seq_array_alloc'; .libs/libindex.a(mail-index-util.o):/tmp/dovecot/src/lib-index/mail-index-util.c:97: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/mail-index-util.o: in function `mail_index_seq_array_add':
/tmp/dovecot/src/lib-index/mail-index-util.c:110: multiple definition of `mail_index_seq_array_add'; .libs/libindex.a(mail-index-util.o):/tmp/dovecot/src/lib-index/mail-index-util.c:110: first defined here
collect2: error: ld returned 1 exit status
rdlibtool: exec error upon slbt_exec_link_create_executable(), line 1745: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 2155.
make[3]: *** [Makefile:800: test-mail-cache] Error 2
make[3]: Leaving directory '/tmp/dovecot/src/lib-index'
make[2]: *** [Makefile:570: all-recursive] Error 1
make[2]: Leaving directory '/tmp/dovecot/src'
make[1]: *** [Makefile:713: all-recursive] Error 1
make[1]: Leaving directory '/tmp/dovecot'
make: *** [Makefile:555: all] Error 2
```
Full build log: [dovecot.slibtool.log](https://github.com/dovecot/core/files/8694259/dovecot.slibtool.log)