### PR TITLE
lib-index/test-mail-index-transaction-update.c: Cleanup timezone instances

### DIFF
--- a/src/lib-index/test-mail-index-transaction-update.c
+++ b/src/lib-index/test-mail-index-transaction-update.c
@@ -648,13 +648,13 @@ static void test_mail_index_update_day_first_uid(void)
 		i_zero(&hdr);
 		for (j = 0; j < N_ELEMENTS(hdr.day_first_uid); j++)
 			hdr.day_first_uid[j] = 8-j;
-		hdr.day_stamp = tests[i].old_day_stamp + timezone;
+		hdr.day_stamp = tests[i].old_day_stamp;
 		memcpy(t->post_hdr_change, &hdr, sizeof(hdr));
-		mail_index_update_day_headers(t, tests[i].now + timezone);
+		mail_index_update_day_headers(t, tests[i].now);
 
 		struct mail_index_header new_hdr;
 		memcpy(&new_hdr, t->post_hdr_change, sizeof(new_hdr));
-		test_assert_idx(new_hdr.day_stamp == tests[i].new_day_stamp + timezone, i);
+		test_assert_idx(new_hdr.day_stamp == tests[i].new_day_stamp, i);
 		test_assert_idx(memcmp(new_hdr.day_first_uid,
 				       tests[i].new_day_first_uid,
 				       sizeof(uint32_t) * 8) == 0, i);


### PR DESCRIPTION
In 1a7b1f66fe the non-standard extern timezone was partially removed, but some instances were left. Since the test is supposed to run with TZ=UTC, and timezone would have been zero anyway, remove them all.

N.B. I noticed this while compiling dovecot on FreeBSD, where `timezone()` is actually a function (see https://www.freebsd.org/cgi/man.cgi?query=timezone)! So this resulted in a bunch of pointer arithmetic and integer conversion errors and warnings:

```
test-mail-index-transaction-update.c:648:42: warning: arithmetic on a pointer to the function type 'char *(int, int)' is a GNU extension [-Wgnu-pointer-arith]
                hdr.day_stamp = tests[i].old_day_stamp + timezone;
                                                       ^ ~~~~~~~~
test-mail-index-transaction-update.c:648:17: error: incompatible pointer to integer conversion assigning to 'uint32_t' (aka 'unsigned int') from 'char *(*)(int, int)' [-Wint-conversion]
                hdr.day_stamp = tests[i].old_day_stamp + timezone;
                              ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test-mail-index-transaction-update.c:650:49: warning: arithmetic on a pointer to the function type 'char *(int, int)' is a GNU extension [-Wgnu-pointer-arith]
                mail_index_update_day_headers(t, tests[i].now + timezone);
                                                              ^ ~~~~~~~~
test-mail-index-transaction-update.c:650:36: error: incompatible pointer to integer conversion passing 'char *(*)(int, int)' to parameter of type 'time_t' (aka 'long') [-Wint-conversion]
                mail_index_update_day_headers(t, tests[i].now + timezone);
                                                 ^~~~~~~~~~~~~~~~~~~~~~~
```
