### PR TITLE
Add UTF8 LMTP server support

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
+ - add UTF8 LMTP server support to be compatible with Postfix SMTPUTF8 (https://unix.stackexchange.com/questions/320091/configure-postfix-and-dovecot-lmtp-to-receive-mail-via-smtputf8)
  - remove mail_deliver_session after all, do all the stuff transparently
    by hooking into mailbox_copy().
      - use this hook also to do the mail deduplication: 1) sort all destination


### PR DESCRIPTION
Related links :
https://unix.stackexchange.com/questions/320091/configure-postfix-and-dovecot-lmtp-to-receive-mail-via-smtputf8
https://github.com/docker-mailserver/docker-mailserver/issues/1117