### PR TITLE
Update legacy /var/run directory to /run

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,9 +185,9 @@ AS_HELP_STRING([--with-ssldir=DIR], [SSL base directory for certificates (/etc/s
 AC_SUBST(ssldir)
 
 AC_ARG_WITH(rundir,
-AS_HELP_STRING([--with-rundir=DIR], [Runtime data directory (LOCALSTATEDIR/run/dovecot)]),
+AS_HELP_STRING([--with-rundir=DIR], [Runtime data directory (/run/dovecot)]),
 	rundir="$withval",
-	rundir=$localstatedir/run/$PACKAGE
+	rundir=/run/$PACKAGE
 )
 AC_SUBST(rundir)
 

--- a/doc/example-config/conf.d/10-mail.conf
+++ b/doc/example-config/conf.d/10-mail.conf
@@ -212,7 +212,7 @@ namespace inbox {
 
 # UNIX socket path to master authentication server to find users.
 # This is used by imap (for shared users) and lda.
-#auth_socket_path = /var/run/dovecot/auth-userdb
+#auth_socket_path = /run/dovecot/auth-userdb
 
 # Directory where to look up mail plugins.
 #mail_plugin_dir = /usr/lib/dovecot

--- a/doc/example-config/dovecot-sql.conf.ext
+++ b/doc/example-config/dovecot-sql.conf.ext
@@ -60,7 +60,7 @@
 #                              the default my.cnf location
 #     option_group           - Read options from the given group (default: client)
 # 
-#   You can connect to UNIX sockets by using host: host=/var/run/mysql.sock
+#   You can connect to UNIX sockets by using host: host=/run/mysql.sock
 #   Note that currently you can't use spaces in parameters.
 #
 # sqlite:

--- a/doc/example-config/dovecot.conf
+++ b/doc/example-config/dovecot.conf
@@ -31,7 +31,7 @@
 #listen = *, ::
 
 # Base directory where to store runtime data.
-#base_dir = /var/run/dovecot/
+#base_dir = /run/dovecot/
 
 # Name of this instance. In multi-instance setup doveadm and other commands
 # can use -i <instance_name> to select which instance is used (an alternative

--- a/src/lib-dict/test-dict-client.c
+++ b/src/lib-dict/test-dict-client.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 
 	i_zero(&set);
 	i_zero(&opset);
-	set.base_dir = "/var/run/dovecot";
+	set.base_dir = "/run/dovecot";
 	opset.username = "testuser";
 
 	if (dict_init(uri, &set, &dict, &error) < 0)

--- a/src/lib-http/test-http-client-errors.c
+++ b/src/lib-http/test-http-client-errors.c
@@ -674,7 +674,7 @@ static void test_invalid_redirect_input2(struct server_connection *conn)
 {
 	static const char *resp =
 		"HTTP/1.1 302 Redirect\r\n"
-		"Location: unix:/var/run/dovecot/auth-master\r\n"
+		"Location: unix:/run/dovecot/auth-master\r\n"
 		"\r\n";
 
 	o_stream_nsend_str(conn->conn.output, resp);

--- a/src/master/master-settings.c
+++ b/src/master/master-settings.c
@@ -906,7 +906,7 @@ void master_settings_do_fixes(const struct master_settings *set)
 	const char *empty_dir;
 	struct stat st;
 
-	/* since base dir is under /var/run by default, it may have been
+	/* since base dir is under /run by default, it may have been
 	   deleted. */
 	if (mkdir_parents(set->base_dir, 0755) < 0 && errno != EEXIST)
 		i_fatal("mkdir(%s) failed: %m", set->base_dir);


### PR DESCRIPTION
Updated legacy /var/run directory to /run.

`Dec 14 20:15:03 hostname.example.com systemd-tmpfiles[499]: /usr/lib/tmpfiles.d/dovecot.conf:1: Line references path below legacy directory /var/run/, updating /var/run/dovecot → /run/dovecot; please update the tmpfiles.d/ drop-in file accordingly.`

Refs:
https://access.redhat.com/solutions/4154291
https://bugs.launchpad.net/ubuntu/+source/dbus/+bug/1854314