### PR TITLE
lib: md5: Fix strict aliasing violation

### DIFF
--- a/src/lib/md5.c
+++ b/src/lib/md5.c
@@ -38,20 +38,6 @@
 	(a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s)))); \
 	(a) += (b);
 
-/*
- * SET reads 4 input bytes in little-endian byte order and stores them
- * in a properly aligned word in host byte order.
- *
- * The check for little-endian architectures which tolerate unaligned
- * memory accesses is just an optimization.  Nothing will break if it
- * doesn't work.
- */
-#if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
-#define SET(n) \
-	(*(const uint32_t *)&ptr[(n) * 4])
-#define GET(n) \
-	SET(n)
-#else
 #define SET(n) \
 	(ctx->block[(n)] = \
 	(uint_fast32_t)ptr[(n) * 4] | \
@@ -60,7 +46,6 @@
 	((uint_fast32_t)ptr[(n) * 4 + 3] << 24))
 #define GET(n) \
 	(ctx->block[(n)])
-#endif
 
 /*
  * This processes one or more 64-byte data blocks, but does NOT update


### PR DESCRIPTION
Followup to f0c1cf42ea78d22e2674b03fe65f0ee6545c5b99. It's exactly the same code as in md4, so let's rip it out here too.

Thanks to sirainen for pointing this out.

Bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=997513
Reference: https://github.com/dovecot/core/pull/195