### PR TITLE
Fix attachment detection

### DIFF
--- a/src/lib-mail/Makefile.am
+++ b/src/lib-mail/Makefile.am
@@ -99,6 +99,7 @@ test_programs = \
 	test-message-id \
 	test-message-parser \
 	test-message-part \
+	test-message-part-data \
 	test-message-part-serialize \
 	test-message-search \
 	test-message-size \
@@ -202,6 +203,10 @@ test_message_parser_DEPENDENCIES = $(test_deps)
 test_message_part_SOURCES = test-message-part.c
 test_message_part_LDADD = $(test_libs)
 test_message_part_DEPENDENCIES = $(test_deps)
+
+test_message_part_data_SOURCES = test-message-part-data.c
+test_message_part_data_LDADD = $(test_libs)
+test_message_part_data_DEPENDENCIES = $(test_deps)
 
 test_message_search_SOURCES = test-message-search.c
 test_message_search_LDADD = $(test_libs) ../lib-charset/libcharset.la

--- a/src/lib-mail/message-part-data.c
+++ b/src/lib-mail/message-part-data.c
@@ -588,7 +588,9 @@ bool message_part_is_attachment(struct message_part *part,
 	if (null_strcasecmp(data->content_disposition, "attachment") == 0 ||
 	    (!set->exclude_inlined &&
 	     null_strcasecmp(data->content_disposition, "inline") == 0 &&
-	     message_part_has_parameter(part, "filename", FALSE)))
+	     (message_part_has_parameter(part, "filename", FALSE) ||
+	        message_part_has_parameter(part, "filename*", FALSE)
+	     )))
 		return TRUE;
 	return FALSE;
 }

--- a/src/lib-mail/test-message-part-data.c
+++ b/src/lib-mail/test-message-part-data.c
@@ -1,0 +1,138 @@
+/* Copyright (c) 2014-2018 Dovecot authors, see the included COPYING file */
+
+#include "lib.h"
+#include "istream.h"
+#include "message-parser.h"
+#include "test-common.h"
+#include "message-part-data.h"
+
+static int message_parse_stream(pool_t pool, struct istream *input,
+				const struct message_parser_settings *set,
+				bool parse_data, struct message_part **parts_r)
+{
+	int ret;
+	struct message_parser_ctx *parser;
+	struct message_block block;
+
+	i_zero(&block);
+	parser = message_parser_init(pool, input, set);
+	while ((ret = message_parser_parse_next_block(parser, &block)) > 0)
+		if (parse_data)
+			message_part_data_parse_from_header(pool, block.part,
+							    block.hdr);
+	message_parser_deinit(&parser, parts_r);
+	test_assert(input->stream_errno == 0);
+	return ret;
+}
+
+static void test_message_part_attachment_detection(const char test_name[],
+    const char input_msg_part[], bool is_expected_attachment)
+{
+	const struct message_parser_settings parser_set = {
+		.max_total_mime_parts = 2,
+	};
+    const struct message_part_attachment_settings set_attachment_settings = {
+        .content_type_filter = NULL,
+        .exclude_inlined = FALSE,
+    };
+	struct istream *input;
+	struct message_part *parts, *part;
+	pool_t pool;
+
+    test_begin(test_name);
+
+	pool = pool_alloconly_create("message parser", 10240);
+	input = test_istream_create(input_msg_part);
+
+	message_parse_stream(pool, input, &parser_set, TRUE, &parts);
+	part = parts;
+
+	test_assert(message_part_is_attachment(part, &set_attachment_settings) == is_expected_attachment);
+
+	i_stream_unref(&input);
+	pool_unref(&pool);
+
+	test_end();
+}
+
+static void test_message_inline_with_filename(void)
+{
+    const char test_name_filename_star[] = "attachment detection disposition inline with filename*";
+    const char input_msg_part_inline_att_with_filename_star[] =
+        "Content-Disposition: inline;filename*=\"foo.bar\"\n"
+        "Content-Type: foo/bar;\n"
+        "\n"
+        "xxxdata\n";
+
+    const char test_name_filename[] = "attachment detection disposition inline with filename";
+    const char input_msg_part_inline_att_with_filename[] =
+        "Content-Disposition: inline;filename=\"foo.bar\"\n"
+        "Content-Type: foo/bar;\n"
+        "\n"
+        "xxxdata\n";
+
+    test_message_part_attachment_detection(test_name_filename_star,
+        input_msg_part_inline_att_with_filename_star, TRUE);
+    test_message_part_attachment_detection(test_name_filename,
+        input_msg_part_inline_att_with_filename, TRUE);
+}
+
+static void test_message_inline_without_filename(void)
+{
+    const char test_name[] = "attachment detection disposition inline without filename";
+    const char input_msg_part[] =
+        "Content-Disposition: inline;\n"
+        "Content-Type: foo/bar;\n"
+        "\n"
+        "xxxdata\n";
+
+    test_message_part_attachment_detection(test_name, input_msg_part, FALSE);
+}
+
+static void test_message_attachment_without_filename(void)
+{
+    const char test_name[] = "attachment detection disposition attachment without filename";
+    const char input_msg_part[] =
+        "Content-Disposition: attachment;\n"
+        "Content-Type: foo/bar;\n"
+        "\n"
+        "xxxdata\n";
+
+    test_message_part_attachment_detection(test_name, input_msg_part, TRUE);
+}
+
+static void test_message_attachment_with_filename(void)
+{
+    const char test_name[] = "attachment detection disposition attachment with filename";
+    const char input_msg_part[] =
+        "Content-Disposition: attachment;filename=\"foo.bar\"\n"
+        "Content-Type: foo/bar;\n"
+        "\n"
+        "xxxdata\n";
+
+    test_message_part_attachment_detection(test_name, input_msg_part, TRUE);
+}
+
+static void test_message_without_attachment(void)
+{
+    const char test_name[] = "attachment detection not attachment";
+    const char input_msg_part[] =
+        "Content-Type: foo/bar;\n"
+        "\n"
+        "xxxdata\n";
+
+    test_message_part_attachment_detection(test_name, input_msg_part, FALSE);
+}
+
+int main(void)
+{
+	static void (*const test_functions[])(void) = {
+		test_message_inline_with_filename,
+		test_message_inline_without_filename,
+		test_message_attachment_without_filename,
+		test_message_attachment_with_filename,
+		test_message_without_attachment,
+		NULL
+	};
+	return test_run(test_functions);
+}

--- a/src/lib-mail/test-message-part-data.c
+++ b/src/lib-mail/test-message-part-data.c
@@ -3,8 +3,8 @@
 #include "lib.h"
 #include "istream.h"
 #include "message-parser.h"
-#include "test-common.h"
 #include "message-part-data.h"
+#include "test-common.h"
 
 static int message_parse_stream(pool_t pool, struct istream *input,
 				const struct message_parser_settings *set,


### PR DESCRIPTION
Hi there,

## Description
Attachment detection on specific case do not works as expected (inline attachment with encoded filename)

## How to reproduce

Tested on latest dovecot version 2.3.20 with the following option:

`mail_attachment_detection_options = add-flags-on-save`

1. Simply add the following email to a mailbox [sample.eml.txt](https://github.com/dovecot/core/files/11381177/sample.eml.txt)
2. Check out the email flags. The email is flagged with $HasNoAttachment instead of $HasAttachment

## Description of the issue

In some case mime-part could have encoded header parameters. It was originally define in the RFC 5987
https://datatracker.ietf.org/doc/html/rfc5987 for the http headers but some applications use it in mime context.

For example Mail.app, adding an inline attachment named "Capture d’écran 2023-05-03 à 11.11.51.png" will produce this kind of part headers:

```
--Apple-Mail=_7891A530-DCCC-4BEA-8EEA-00884364DDF8
Content-Transfer-Encoding: base64
Content-Disposition: inline;
	filename*=utf-8''Capture%20d%E2%80%99e%CC%81cran%202023%2D05%2D03%20a%CC%80%2011.11.51.png
Content-Type: image/png;
	x-mac-hide-extension=yes;
	x-unix-mode=0644;
	name="=?utf-8?B?Q2FwdHVyZSBk4oCZZcyBY3JhbiAyMDIzLTA1LTAzIGHMgCAxMS4xMS41MS5w?=
 =?utf-8?B?bmc=?="
Content-Id: <2EFC0CEF-22B3-44F5-B767-88063E274334>
```

Attachment detection for inline part defined in the lib-mail/message-part-data was strict on the header parameter and only
check for the parameter==="filename".

## The fix
I've simply add another condition on the inline attachment detection to handle encoded "filename"

