### PR TITLE
fix segfault when pgsql connection fails

### DIFF
--- a/src/lib-sql/driver-pgsql.c
+++ b/src/lib-sql/driver-pgsql.c
@@ -1281,13 +1281,13 @@ static void driver_pgsql_wait(struct sql_db *_db)
 	if (!driver_pgsql_have_work(db))
 		return;
 
-	struct ioloop *prev_ioloop = current_ioloop;
+	db->orig_ioloop = current_ioloop;
 	db->ioloop = io_loop_create();
 	db->io = io_loop_move_io(&db->io);
 	while (driver_pgsql_have_work(db))
 		io_loop_run(db->ioloop);
 
-	io_loop_set_current(prev_ioloop);
+	io_loop_set_current(db->orig_ioloop);
 	db->io = io_loop_move_io(&db->io);
 	io_loop_set_current(db->ioloop);
 	io_loop_destroy(&db->ioloop);


### PR DESCRIPTION
`auth` crashes with segfault when wrong postgres userdb credentials are provided.
This is the stacktrace:

```
#0  timeout_add_common (ioloop=0x0, source_filename=0x5555555b3ce6 "driver-sqlpool.c", source_linenum=242, 
    callback=0x55555559fcf9 <sqlpool_reconnect>, context=0x555555601290) at ioloop.c:273
#1  0x00007ffff7edb818 in timeout_add_to (ioloop=0x0, msecs=1000, source_filename=0x5555555b3ce6 "driver-sqlpool.c", 
    source_linenum=242, callback=0x55555559fcf9 <sqlpool_reconnect>, context=0x555555601290) at ioloop.c:289
#2  0x00007ffff7edb900 in timeout_add (msecs=1000, source_filename=0x5555555b3ce6 "driver-sqlpool.c", source_linenum=242, 
    callback=0x55555559fcf9 <sqlpool_reconnect>, context=0x555555601290) at ioloop.c:312
#3  0x000055555559ff4a in sqlpool_handle_connect_failed (db=0x5555556009c0, conndb=0x555555601290) at driver-sqlpool.c:242
#4  0x00005555555a004c in sqlpool_state_changed (conndb=0x555555601290, prev_state=SQL_DB_STATE_CONNECTING, context=0x5555556009c0)
    at driver-sqlpool.c:269
#5  0x000055555559efb1 in sql_db_set_state (db=0x555555601290, state=SQL_DB_STATE_DISCONNECTED) at sql-api.c:793
#6  0x00005555555a43ea in driver_pgsql_set_state (db=0x555555601290, state=SQL_DB_STATE_DISCONNECTED) at driver-pgsql.c:110
#7  0x00005555555a4533 in driver_pgsql_close (db=0x555555601290) at driver-pgsql.c:148
#8  0x00005555555a4706 in connect_callback (db=0x555555601290) at driver-pgsql.c:196
#9  0x00007ffff7edcc4e in io_loop_call_io (io=0x55555561fbf0) at ioloop.c:737
#10 0x00007ffff7ee02b2 in io_loop_handler_run_internal (ioloop=0x55555561cbb0) at ioloop-epoll.c:222
#11 0x00007ffff7edced5 in io_loop_handler_run (ioloop=0x55555561cbb0) at ioloop.c:789
#12 0x00007ffff7edcdb0 in io_loop_run (ioloop=0x55555561cbb0) at ioloop.c:762
#13 0x00005555555a7fe1 in driver_pgsql_wait (_db=0x555555601290) at driver-pgsql.c:1288
#14 0x000055555559f2ed in sql_wait (db=0x555555601290) at sql-api.c:861
#15 0x00005555555a4d8a in driver_pgsql_get_flags (db=0x555555601290) at driver-pgsql.c:314
#16 0x000055555559d79b in sql_get_flags (db=0x555555601290) at sql-api.c:171
#17 0x00005555555a071c in driver_sqlpool_get_flags (_db=0x5555556009c0) at driver-sqlpool.c:448
#18 0x000055555559d79b in sql_get_flags (db=0x5555556009c0) at sql-api.c:171
#19 0x000055555558e342 in passdb_sql_init (_module=0x5555555ee9f8) at passdb-sql.c:285
#20 0x000055555558a679 in passdb_init (passdb=0x5555555ee9f8) at passdb.c:236
#21 0x0000555555567771 in auth_passdb_init (passdb=0x5555555ee8e8) at auth.c:332
#22 0x0000555555567840 in auth_init (auth=0x5555555ee8a8) at auth.c:347
#23 0x0000555555567fd9 in auths_init () at auth.c:462
#24 0x0000555555566308 in main_init () at main.c:233
#25 0x0000555555566792 in main (argc=1, argv=0x5555555ec940) at main.c:386
```

The reason seems to be that `db->orig_ioloop` is `NULL` when working with timeouts.
