### PR TITLE
oauth2+pgsql db crash workaround

### DIFF
--- a/src/auth/db-oauth2.c
+++ b/src/auth/db-oauth2.c
@@ -254,7 +254,7 @@ struct db_oauth2 *db_oauth2_init(const char *config_path)
 	http_set.debug = db->set.debug;
 	http_set.event_parent = auth_event;
 
-	db->client = http_client_init(&http_set);
+	db->client = http_client_init_private(&http_set);
 
 	i_zero(&db->oauth2_set);
 	db->oauth2_set.client = db->client;


### PR DESCRIPTION
When enabling oauth2 and postgres user db, `auth` crashes due to a failed assertion:

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff7ae7537 in __GI_abort () at abort.c:79
#2  0x00007ffff7eb4055 in default_fatal_finish (type=LOG_TYPE_PANIC, status=0) at failures.c:464
#3  0x00007ffff7eb40bc in fatal_handler_real (ctx=0x7fffffffe770, 
    format=0x7ffff7f39748 "file %s: line %d (%s): assertion failed: (%s)", args=0x7fffffffe7a0) at failures.c:476
#4  0x00007ffff7eb4106 in default_fatal_handler (ctx=0x7fffffffe770, 
    format=0x7ffff7f39748 "file %s: line %d (%s): assertion failed: (%s)", args=0x7fffffffe7a0) at failures.c:484
#5  0x00007ffff7eb4390 in i_panic (format=0x7ffff7f39748 "file %s: line %d (%s): assertion failed: (%s)") at failures.c:529
#6  0x00007ffff7e1d732 in http_client_context_close (cctx=0x555555602e58) at http-client.c:656
#7  0x00007ffff7e1d92b in http_client_global_context_ioloop_switched (prev_ioloop=0x555555620f40) at http-client.c:720
#8  0x00007ffff7edd7b9 in io_loop_set_current (ioloop=0x0) at ioloop.c:982
#9  0x00005555555a43d9 in driver_pgsql_set_state (db=0x555555601290, state=SQL_DB_STATE_IDLE) at driver-pgsql.c:109
#10 0x00005555555a47cf in connect_callback (db=0x555555601290) at driver-pgsql.c:212
#11 0x00007ffff7edcc4e in io_loop_call_io (io=0x55555565bab0) at ioloop.c:737
#12 0x00007ffff7ee02b2 in io_loop_handler_run_internal (ioloop=0x555555620f40) at ioloop-epoll.c:222
#13 0x00007ffff7edced5 in io_loop_handler_run (ioloop=0x555555620f40) at ioloop.c:789
#14 0x00007ffff7edcdb0 in io_loop_run (ioloop=0x555555620f40) at ioloop.c:762
#15 0x00005555555a7fe1 in driver_pgsql_wait (_db=0x555555601290) at driver-pgsql.c:1288
#16 0x000055555559f2ed in sql_wait (db=0x555555601290) at sql-api.c:861
#17 0x00005555555a4d8a in driver_pgsql_get_flags (db=0x555555601290) at driver-pgsql.c:314
#18 0x000055555559d79b in sql_get_flags (db=0x555555601290) at sql-api.c:171
#19 0x00005555555a071c in driver_sqlpool_get_flags (_db=0x5555556009c0) at driver-sqlpool.c:448
#20 0x000055555559d79b in sql_get_flags (db=0x5555556009c0) at sql-api.c:171
#21 0x000055555558e342 in passdb_sql_init (_module=0x5555555eeb18) at passdb-sql.c:285
#22 0x000055555558a679 in passdb_init (passdb=0x5555555eeb18) at passdb.c:236
#23 0x0000555555567771 in auth_passdb_init (passdb=0x5555555eea08) at auth.c:332
#24 0x0000555555567840 in auth_init (auth=0x5555555ee9c8) at auth.c:347
#25 0x0000555555567fd9 in auths_init () at auth.c:462
#26 0x0000555555566308 in main_init () at main.c:233
#27 0x0000555555566792 in main (argc=1, argv=0x5555555ec940) at main.c:386
```

It seems to be related to the way pgsql driver switches iocontext.
Using a private context for http_client in db_oauth2 seems to solve the problem.

I've seen this workaround applied here as well:
https://github.com/dovecot/core/commit/1ff9c5aff4a07e52f830fd005a9713b92f0719c8