### PR TITLE
Fix an infinite loop

### DIFF
--- a/src/doveadm/dsync/dsync-mailbox-tree.c
+++ b/src/doveadm/dsync/dsync-mailbox-tree.c
@@ -268,6 +268,7 @@ convert_name_to_remote_sep(struct dsync_mailbox_tree *tree, const char *name)
 		const char *end = strchr(name, tree->sep);
 		const char *name_part = end == NULL ? name :
 			t_strdup_until(name, end++);
+		name = end;
 
 		if (tree->escape_char != '\0')
 			mailbox_list_name_unescape(&name_part, tree->escape_char);


### PR DESCRIPTION
Be sure to update 'name' when traversing the components of a path in convert_name_to_remote_sep.  Otherwise we end up allocating a lot of memory and failing.