### PR TITLE
Silence prototype conflicts

### DIFF
--- a/src/auth/db-lua.h
+++ b/src/auth/db-lua.h
@@ -23,9 +23,10 @@ struct auth_lua_script_parameters {
 int auth_lua_script_init(const struct auth_lua_script_parameters *params,
 		         const char **error_r);
 
-int auth_lua_call_password_verify(struct dlua_script *script,
-				  struct auth_request *req, const char *password,
-				  const char **error_r);
+enum passdb_result
+auth_lua_call_password_verify(struct dlua_script *script,
+			      struct auth_request *req, const char *password,
+			      const char **error_r);
 
 enum passdb_result
 auth_lua_call_passdb_lookup(struct dlua_script *script,

--- a/src/lib-program-client/program-client.c
+++ b/src/lib-program-client/program-client.c
@@ -706,7 +706,7 @@ program_client_run_callback(int result, int *context)
 	io_loop_stop(current_ioloop);
 }
 
-int program_client_run(struct program_client *pclient)
+enum program_client_exit_status program_client_run(struct program_client *pclient)
 {
 	int ret = -2;
 	struct ioloop *prev_ioloop = current_ioloop;
@@ -726,7 +726,7 @@ int program_client_run(struct program_client *pclient)
 	io_loop_destroy(&ioloop);
 
 	if (pclient->error != PROGRAM_CLIENT_ERROR_NONE)
-		return -1;
+		return PROGRAM_CLIENT_EXIT_STATUS_INTERNAL_FAILURE;
 
 	return pclient->exit_status;
 }


### PR DESCRIPTION
    program-client.c:705:5: warning: conflicting types for 'program_client_run' due to enum/integer mismatch; have 'int(struct program_client *)' [-Wenum-int-mismatch]
      705 | int program_client_run(struct program_client *pclient)
          |     ^~~~~~~~~~~~~~~~~~
    In file included from program-client-private.h:4,
                     from program-client.c:17:
    program-client.h:93:1: note: previous declaration of 'program_client_run' with type 'enum program_client_exit_status(struct program_client *)'
       93 | program_client_run(struct program_client *pclient);
          | ^~~~~~~~~~~~~~~~~~

    db-lua.c:599:1: warning: conflicting types for 'auth_lua_call_password_verify' due to enum/integer mismatch; have 'enum passdb_result(struct dlua_script *, struct auth_request *, const char *, const char **)' [-Wenum-int-mismatch]
      599 | auth_lua_call_password_verify(struct dlua_script *script,
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from db-lua.c:28:
    db-lua.h:14:5: note: previous declaration of 'auth_lua_call_password_verify' with type 'int(struct dlua_script *, struct auth_request *, const char *, const char **)'
       14 | int auth_lua_call_password_verify(struct dlua_script *script,
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~