### PR TITLE
Cleanup temporary build files

### DIFF
--- a/src/plugins/quota/Makefile.am
+++ b/src/plugins/quota/Makefile.am
@@ -126,7 +126,7 @@ clean-generic:
 	if [ "$(top_srcdir)" != "$(top_builddir)" ]; then \
 	  rm -f $(top_builddir)/src/plugins/quota/rquota.x; \
 	fi; \
-	rm -f rquota_xdr.c rquota.h
+	rm -f rquota_xdr.c rquota_xdr.c.tmp rquota.h rquota.h.tmp
 
 test_programs = \
 	test-quota-util


### PR DESCRIPTION
Support building twice:

    dpkg-source: info: local changes detected, the modified files are:
     source/src/plugins/quota/rquota.h.tmp
     source/src/plugins/quota/rquota_xdr.c.tmp