### PR TITLE
Solr/Tika patches for dovecot fts

### DIFF
--- a/src/plugins/fts-solr/fts-backend-solr.c
+++ b/src/plugins/fts-solr/fts-backend-solr.c
@@ -845,7 +845,7 @@ fts_backend_solr_lookup(struct fts_backend *_backend, struct mailbox *box,
 
 	str = t_str_new(256);
 	str_printfa(str, "wt=xml&fl=uid,score&rows=%u&sort=uid+asc&q=%%7b!lucene+q.op%%3dAND%%7d",
-		    status.uidnext);
+		   I_MIN(status.uidnext,SOLR_MAX_MULTI_ROWS)); 
 	prefix_len = str_len(str);
 
 	if (solr_add_definite_query_args(str, args, and_args)) {

--- a/src/plugins/fts/fts-parser-tika.c
+++ b/src/plugins/fts/fts-parser-tika.c
@@ -58,7 +58,7 @@ tika_get_http_client_url(struct fts_parser_context *parser_context, struct http_
 	tuser = p_new(user->pool, struct fts_parser_tika_user, 1);
 	MODULE_CONTEXT_SET(user, fts_parser_tika_user_module, tuser);
 
-	if (http_url_parse(url, NULL, 0, user->pool,
+	if (http_url_parse(url, NULL, HTTP_URL_ALLOW_USERINFO_PART, user->pool,
 			   &tuser->http_url, &error) < 0) {
 		e_error(event, "fts_tika: Failed to parse HTTP url %s: %s", url, error);
 		return -1;
@@ -159,6 +159,11 @@ fts_parser_tika_try_init(struct fts_parser_context *parser_context)
 			http_url->host.name,
 			t_strconcat(http_url->path, http_url->enc_query, NULL),
 			fts_tika_parser_response, parser);
+	if (http_url->user != NULL) {
+		http_client_request_set_auth_simple(
+			http_req, http_url->user, http_url->password);
+	}
+
 	http_client_request_set_port(http_req, http_url->port);
 	http_client_request_set_ssl(http_req, http_url->have_ssl);
 	if (parser_context->content_type != NULL)


### PR DESCRIPTION
The pull request contains three patches against dovecot main branch:

- Tika - allow authentication against Tika server. Allows setting username and password in fts_tika configuration
- Solr - place upper bound on number of rows to be returned from solr for single mailbox search
- Solr - skip indexing when message size exceed a configured value. New configuration: fts_max_size. Defaults to existing behaviour (no limit)