### PR TITLE
storage: remove 500 ms debounce on IMAP IDLE notifications

### DIFF
--- a/src/lib-storage/mail-storage-private.h
+++ b/src/lib-storage/mail-storage-private.h
@@ -455,7 +455,7 @@ struct mailbox {
 	/* Mailbox notification settings: */
 	mailbox_notify_callback_t *notify_callback;
 	void *notify_context;
-	struct timeout *to_notify, *to_notify_delay;
+	struct timeout *to_notify;
 	struct mailbox_notify_file *notify_files;
 
 	/* Increased by one for each new struct mailbox. */

--- a/src/lib-storage/mailbox-watch.c
+++ b/src/lib-storage/mailbox-watch.c
@@ -9,8 +9,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
-#define NOTIFY_DELAY_MSECS 500
-
 struct mailbox_notify_file {
 	struct mailbox_notify_file *next;
 
@@ -19,9 +17,10 @@ struct mailbox_notify_file {
 	struct io *io_notify;
 };
 
-static void notify_delay_callback(struct mailbox *box)
+static void notify_callback(struct mailbox *box)
 {
-	timeout_remove(&box->to_notify_delay);
+	timeout_reset(box->to_notify);
+
 	box->notify_callback(box, box->notify_context);
 }
 
@@ -40,18 +39,7 @@ static void notify_timeout(struct mailbox *box)
 	}
 
 	if (notify)
-		notify_delay_callback(box);
-}
-
-static void notify_callback(struct mailbox *box)
-{
-	timeout_reset(box->to_notify);
-
-	if (box->to_notify_delay == NULL) {
-		box->to_notify_delay =
-			timeout_add_short(NOTIFY_DELAY_MSECS,
-					  notify_delay_callback, box);
-	}
+		notify_callback(box);
 }
 
 void mailbox_watch_add(struct mailbox *box, const char *path)
@@ -97,7 +85,6 @@ void mailbox_watch_remove_all(struct mailbox *box)
 		i_free(file);
 	}
 
-	timeout_remove(&box->to_notify_delay);
 	timeout_remove(&box->to_notify);
 }
 


### PR DESCRIPTION
This commit removes hardcoded 500 ms debounce
from storage that delays all storage notification subscribers such as IDLE and NOTIFY commands.

500 ms debounce constant NOTIFY_DELAY_MSECS
was added in 2009 [1]. Before that Dovecot
was only delivering notifications
when a second-resolution timer
is changed by at least 1, so IDLE notifications
were delayed by half a second on average.

[1] https://github.com/dovecot/core/commit/56fb5d09955b6097f77b341717fd9b70e9f13e7