### PR TITLE
Change of severity level

### DIFF
--- a/src/auth/auth-client-connection.c
+++ b/src/auth/auth-client-connection.c
@@ -410,7 +410,7 @@ static void auth_client_disconnected(struct auth_client_connection **_conn)
 	request_count = conn->request_handler == NULL ? 0 :
 		auth_request_handler_get_request_count(conn->request_handler);
 	if (request_count > 0) {
-		e_error(conn->event, "auth client %u disconnected with %u "
+		e_warning(conn->event, "auth client %u disconnected with %u "
 			  "pending requests: %s", conn->pid, request_count,
 			  err == 0 ? "EOF" : strerror(err));
 	}


### PR DESCRIPTION
When this event was introduced, it was logged as warning as it is non-critical for dovecot's stability
It was (maybe by accident...) elevated to error when the i_info()/i_warning()/i_error() calls where replaced with their e_*() equivalents
(see https://github.com/dovecot/core/commit/66ddc39ad78a7dbb1af3352307b0e54a9c9dff96)
To prevent flooding error logs with non-critical errors, it should be reverted to warning