### PR TITLE
push-notification: fix typo 'module' to '-module'

### DIFF
--- a/src/plugins/push-notification/Makefile.am
+++ b/src/plugins/push-notification/Makefile.am
@@ -75,7 +75,7 @@ lib22_push_notification_lua_plugin_la_CFLAGS = $(AM_CPPFLAGS) \
 	-I$(top_srcdir)/src/lib-lua \
 	-I$(top_srcdir)/src/plugins/mail-lua \
 	$(LUA_CFLAGS)
-lib22_push_notification_lua_plugin_la_LDFLAGS = module -avoid-version
+lib22_push_notification_lua_plugin_la_LDFLAGS = -module -avoid-version
 module_LTLIBRARIES += \
 	lib22_push_notification_lua_plugin.la
 lib22_push_notification_lua_plugin_la_LIBADD = $(notify_deps) $(LUA_LIBS)


### PR DESCRIPTION
There is a typo in the Makefile.am where it has `module` instead of `-module` which causes a build failure with slibtool.
```
ld: cannot find module: No such file or directory
```
With GNU libtool the typo is silently ignored.

This was reported for Gentoo. https://bugs.gentoo.org/913694