### PR TITLE
test-istream-qp-decoder: fix out-of-bounds read

### DIFF
--- a/src/lib-mail/test-istream-qp-decoder.c
+++ b/src/lib-mail/test-istream-qp-decoder.c
@@ -20,7 +20,7 @@ static const struct {
 	{ "p=c3=a4= \t \n=c3=\r\n=a4t=  \r\n=c3=b6s", "p\xC3\xA4\xC3\xA4t\xC3\xB6s", 0, 5 },
 	{ "p=c3=a4= \t \n=c3=\r\n=a4t=  \r\n=c3=b6s", "p\xC3\xA4\xC3\xA4t\xC3\xB6s", 0, 7 },
 	{ "p=c3", "p\xC3", 0, 2 },
-	{ "=0A=0D  ", "\n\r", 0, 7 },
+	{ "=0A=0D  ", "\n\r", 0, 4 },
 	{ "foo_bar", "foo_bar", 0, 0 },
 	{ "\n\n", "\r\n\r\n", 0, 0 },
 	{ "\r\n\n\n\r\n", "\r\n\r\n\r\n\r\n", 0, 0 },


### PR DESCRIPTION
The input string `=0A=0D  ` contains on only four symbols: \n, \r, and two whitespaces.

Reported by address sanitizer:

```
    istream qp decoder 1 ................................................. : ok
    istream qp decoder 2 ................................................. : ok
    istream qp decoder 3 ................................................. : ok
    istream qp decoder 4 ................................................. : ok
    istream qp decoder 5 ................................................. : ok
    istream qp decoder 6 ................................................. : ok
    istream qp decoder 7 ................................................. : ok
    istream qp decoder 8 ................................................. : ok
    istream qp decoder 9 ................................................. : ok
    =================================================================
    ==135439==ERROR: AddressSanitizer: global-buffer-overflow on address 0x561b9fbf5489 at pc 0x561b9fb2601d bp 0x7fffdea7cba0 sp 0x7fffdea7cb98
    READ of size 1 at 0x561b9fbf5489 thread T0
        #0 0x561b9fb2601c in get_encoding_size_diff src/lib-mail/test-istream-qp-decoder.c:76
        #1 0x561b9fb2601c in decode_test src/lib-mail/test-istream-qp-decoder.c:160
        #2 0x561b9fb2601c in test_istream_qp_decoder src/lib-mail/test-istream-qp-decoder.c:183
        #3 0x561b9fb1c97a in test_run_funcs ../lib-test/test-common.c:346
        #4 0x561b9fb1cb1a in test_run ../lib-test/test-common.c:417
        #5 0x561b9fb1cb35 in main src/lib-mail/test-istream-qp-decoder.c:196
        #6 0x7f8d59240c89  (/lib/x86_64-linux-gnu/libc.so.6+0x29c89) (BuildId: 652dfccae16d17796a09de192ed332fd65dc9abb)
        #7 0x7f8d59240d44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29d44) (BuildId: 652dfccae16d17796a09de192ed332fd65dc9abb)
        #8 0x561b9fb05bc0 in _start (/build/dovecot-2.3.21+dfsg1/src/lib-mail/test-istream-qp-decoder+0x184bc0) (BuildId: c3eb31a408186312e51514f84e299274e772e6ae)

    0x561b9fbf5489 is located 55 bytes before global variable '*.LC247' defined in './test-istream-qp-decoder.ltrans0.ltrans' (0x561b9fbf54c0) of size 3
      '*.LC247' is ascii string '
    '
    0x561b9fbf5489 is located 0 bytes after global variable '*.LC246' defined in './test-istream-qp-decoder.ltrans0.ltrans' (0x561b9fbf5480) of size 9
      '*.LC246' is ascii string '=0A=0D  '
    SUMMARY: AddressSanitizer: global-buffer-overflow src/lib-mail/test-istream-qp-decoder.c:76 in get_encoding_size_diff
    Shadow bytes around the buggy address:
      0x561b9fbf5200: f9 f9 f9 f9 00 00 03 f9 f9 f9 f9 f9 00 00 00 01
      0x561b9fbf5280: f9 f9 f9 f9 00 00 03 f9 f9 f9 f9 f9 00 00 06 f9
      0x561b9fbf5300: f9 f9 f9 f9 00 02 f9 f9 f9 f9 f9 f9 00 00 00 02
      0x561b9fbf5380: f9 f9 f9 f9 00 00 00 00 03 f9 f9 f9 f9 f9 f9 f9
      0x561b9fbf5400: 05 f9 f9 f9 f9 f9 f9 f9 03 f9 f9 f9 f9 f9 f9 f9
    =>0x561b9fbf5480: 00[01]f9 f9 f9 f9 f9 f9 03 f9 f9 f9 f9 f9 f9 f9
      0x561b9fbf5500: 00 f9 f9 f9 f9 f9 f9 f9 03 f9 f9 f9 f9 f9 f9 f9
      0x561b9fbf5580: 05 f9 f9 f9 f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9
      0x561b9fbf5600: 00 01 f9 f9 f9 f9 f9 f9 00 00 03 f9 f9 f9 f9 f9
      0x561b9fbf5680: 07 f9 f9 f9 f9 f9 f9 f9 00 00 00 04 f9 f9 f9 f9
      0x561b9fbf5700: 00 00 00 f9 f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9
    Shadow byte legend (one shadow byte represents 8 application bytes):
      Addressable:           00
      Partially addressable: 01 02 03 04 05 06 07
      Heap left redzone:       fa
      Freed heap region:       fd
      Stack left redzone:      f1
      Stack mid redzone:       f2
      Stack right redzone:     f3
      Stack after return:      f5
      Stack use after scope:   f8
      Global redzone:          f9
      Global init order:       f6
      Poisoned by user:        f7
      Container overflow:      fc
      Array cookie:            ac
      Intra object redzone:    bb
      ASan internal:           fe
      Left alloca redzone:     ca
      Right alloca redzone:    cb
    ==135439==ABORTING
```

Fixes: e3b45a1e30 ("lib-mail: Extend quoted-printable decoding tests")