### PR TITLE
replicator: fixed infinity loop on sync replication

### DIFF
--- a/src/replication/replicator/replicator-queue.c
+++ b/src/replication/replicator/replicator-queue.c
@@ -333,6 +333,7 @@ replicator_queue_handle_sync_lookups(struct replicator_queue *queue,
 		} else {
 			array_push_back(&callbacks, &lookups[i]);
 			array_delete(&queue->sync_lookups, i, 1);
+			count--;
 		}
 	}
 


### PR DESCRIPTION
Before this fix, replicator adds the same lookup into callbacks over and over, until it reaches out of memory, and crashes.

This regression was introduced 447e086422f1ab7cc16833583ed70a4af7a84bc5 with initial implementation of replicator.
