### PR TITLE
Remove hard coded paths from solr-config-9.xml

### DIFF
--- a/doc/solr-config-9.xml
+++ b/doc/solr-config-9.xml
@@ -75,8 +75,8 @@
     <!-- <lib dir="${solr.install.dir:../../../..}/modules/ltr/lib" regex=".*\.jar" /> -->
 
     <!-- Load ICU analyser -->
-    <lib dir="/opt/solr/modules/analysis-extras/lib" regex="icu4j-70.1.jar"/>
-    <lib dir="/opt/solr/modules/analysis-extras/lib" regex="lucene-analysis-icu-9.8.0.jar"/>
+    <lib dir="${solr.install.dir}/modules/analysis-extras/lib" regex="icu4j-.*\.jar"/>
+    <lib dir="${solr.install.dir}/modules/analysis-extras/lib" regex="lucene-analysis-icu-.*\.jar"/>
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged
        if it can't be loaded.


### PR DESCRIPTION
Dovecot includes a config file for use with Solr 9. However, this file has two problems:

 * it hard codes the path to the Solr installation
 * it hard codes version numbers of ICU analyser packages

This commit removes hard-coded Solr installation path and uses the variable `${solr.install.dir}` instead. It also uses a regex for loading the ICU analyser packages.