### PR TITLE
link against icu-uc for icu >= 76

### DIFF
--- a/m4/want_icu.m4
+++ b/m4/want_icu.m4
@@ -2,7 +2,7 @@ AC_DEFUN([DOVECOT_WANT_ICU], [
   have_icu=no
 
   AS_IF([test "$want_icu" != "no"], [
-    PKG_CHECK_MODULES([LIBICU], [icu-i18n], [have_icu=yes], [
+    PKG_CHECK_MODULES([LIBICU], [icu-i18n icu-uc], [have_icu=yes], [
       have_icu=no
 
       AS_IF([test "$want_icu" = "yes"], [


### PR DESCRIPTION
In icu >= 76, `icu-i18n` and `icu-uc` becomes separated libs, so we should link against `icu-uc` explicitly.