### PR TITLE
Update mmap_write.m4 Enhance Security by Replacing strcpy() with strncpy()

### DIFF
--- a/m4/mmap_write.m4
+++ b/m4/mmap_write.m4
@@ -25,7 +25,7 @@ AC_DEFUN([DOVECOT_MMAP_WRITE], [
           perror("mmap()");
           return 1;
         }
-        strcpy(mem, "2");
+        strncpy(mem, "2");
         msync(mem, 2, MS_SYNC);
         lseek(f, 0, SEEK_SET);
         write(f, "3", 2);


### PR DESCRIPTION
In this PR replaces instances of strcpy() with strncpy() to mitigate the risk of buffer overflows. strncpy() ensures safer handling of strings by limiting the number of copied characters and adding null-termination, enhancing the overall security and stability of the code.