### PR TITLE
lib: test-data-stack - Drop bogus assertion

### DIFF
--- a/src/lib/test-data-stack.c
+++ b/src/lib/test-data-stack.c
@@ -188,7 +188,6 @@ static void test_ds_buffers(void)
 		void *b = t_buffer_get(1000);
 		void *a = t_malloc_no0(1);
 		void *b2 = t_buffer_get(1001);
-		test_assert(a == b); /* expected, not guaranteed */
 		test_assert(b2 != b);
 	} T_END;
 	test_end();


### PR DESCRIPTION
This assertion goes back to 992a1726a41b42fa47204565ff17f7c635fcb421 when test-data-stack.c was added.

It starts to fail with (upcoming) GCC 15 which has improvements for optimising out redundant pointer-vs-pointer comparisons, specifically r15-580-gf3e5f4c58591f5 for gcc bug PR13962.

Anyway, this is a problem for this assertion because t_malloc_no0 is marked with `__attribute__((malloc))` which guarantees that the returned pointer doesn't alias, hence a == b must be false.

Bug: https://bugs.gentoo.org/939857