### PR TITLE
build(macos): add some patches to fix macos builds

### DIFF
--- a/src/lib/compat.h
+++ b/src/lib/compat.h
@@ -31,13 +31,15 @@ int rand_r(unsigned int*) __attribute__((deprecated("Do not use rand_r, use i_ra
 /* NOLINTEND(readability-redundant-declaration) */
 #endif
 
-#if defined (HAVE_UOFF_T)
+#if defined(__APPLE__)
+typedef size_t uoff_t;
+#elif defined(HAVE_UOFF_T)
 /* native support */
-#elif defined (UOFF_T_INT)
+#elif defined(UOFF_T_INT)
 typedef unsigned int uoff_t;
-#elif defined (UOFF_T_LONG)
+#elif defined(UOFF_T_LONG)
 typedef unsigned long uoff_t;
-#elif defined (UOFF_T_LONG_LONG)
+#elif defined(UOFF_T_LONG_LONG)
 typedef unsigned long long uoff_t;
 #else
 #  error uoff_t size not set

--- a/src/plugins/var-expand-crypt/Makefile.am
+++ b/src/plugins/var-expand-crypt/Makefile.am
@@ -21,6 +21,12 @@ lib20_auth_var_expand_crypt_la_SOURCES = \
 lib20_var_expand_crypt_la_SOURCES = \
 	var-expand-crypt-plugin.c
 
+lib20_var_expand_crypt_la_LIBADD = \
+       $(top_builddir)/src/lib/liblib.la \
+       $(top_builddir)/src/lib-json/libjson.la \
+       $(top_builddir)/src/lib-dcrypt/libdcrypt.la \
+       $(top_builddir)/src/lib-var-expand/libvar_expand.la
+
 test_programs = test-var-expand-crypt
 
 test_var_expand_crypt_CFLAGS = \
@@ -33,6 +39,12 @@ test_var_expand_crypt_LDADD = \
 test_var_expand_crypt_DEPENDENCIES = \
 	$(LIBDOVECOT_DEPS) \
 	lib20_auth_var_expand_crypt.la
+
+lib20_auth_var_expand_crypt_la_LIBADD = \
+       $(top_builddir)/src/lib/liblib.la \
+       $(top_builddir)/src/lib-json/libjson.la \
+       $(top_builddir)/src/lib-dcrypt/libdcrypt.la \
+       $(top_builddir)/src/lib-var-expand/libvar_expand.la
 
 check-local:
 	for bin in $(test_programs); do \


### PR DESCRIPTION
seeing some macos build failures as:

```
http-server-settings.c:34:2: error: array size is negative
   34 |         DEF(SIZE_HIDDEN, socket_send_buffer_size),
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
http-server-settings.c:13:2: note: expanded from macro 'DEF'
   13 |         SETTING_DEFINE_STRUCT_##type("http_server_"#name, name, struct http_server_settings)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:138:1: note: expanded from here
  138 | SETTING_DEFINE_STRUCT_SIZE_HIDDEN
      | ^
../../src/lib-settings/settings-parser.h:125:2: note: expanded from macro 'SETTING_DEFINE_STRUCT_SIZE_HIDDEN'
  125 |         SETTING_DEFINE_STRUCT_TYPE(SET_SIZE, SET_FLAG_HIDDEN, uoff_t, key, name, struct_name)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/lib-settings/settings-parser.h:78:27: note: expanded from macro 'SETTING_DEFINE_STRUCT_TYPE'
   78 |         { .type = (_enum_type) + COMPILE_ERROR_IF_TYPES_NOT_COMPATIBLE( \
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   79 |                 ((_struct_name *)0)->_name, _c_type), \
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/lib/macros.h:182:2: note: expanded from macro 'COMPILE_ERROR_IF_TYPES_NOT_COMPATIBLE'
  182 |         COMPILE_ERROR_IF_TRUE( \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
  183 |                 !__builtin_types_compatible_p(typeof(_a), typeof(_b)))
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/lib/macros.h:173:15: note: expanded from macro 'COMPILE_ERROR_IF_TRUE'
  173 |         (sizeof(char[1 - 2 * ((condition) ? 1 : 0)]) > 0 ? FALSE : FALSE)
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Define `uoff_t` as `size_t` to fix type mismatch.

relates to https://github.com/Homebrew/homebrew-core/pull/205422