### PR TITLE
Add missing class attribute to standard tokenizer in Solr schema.xml

### DIFF
--- a/doc/solr-schema-9.xml
+++ b/doc/solr-schema-9.xml
@@ -6,7 +6,7 @@
   <fieldType name="string" class="solr.StrField" omitNorms="true" sortMissingLast="true"/>
   <fieldType name="text" class="solr.TextField" autoGeneratePhraseQueries="true" positionIncrementGap="100">
     <analyzer type="index">
-      <tokenizer name="standard" />
+      <tokenizer name="standard" class="solr.StandardTokenizerFactory"/>
       <filter name="icuFolding" />
       <filter name="wordDelimiterGraph" catenateNumbers="1" generateNumberParts="1" splitOnCaseChange="1" generateWordParts="1" splitOnNumerics="1" catenateAll="1" catenateWords="1"/>
       <filter name="flattenGraph"/>
@@ -14,7 +14,7 @@
       <filter name="porterStem"/>
     </analyzer>
     <analyzer type="query">
-      <tokenizer name="standard" />
+      <tokenizer name="standard" class="solr.StandardTokenizerFactory"/>
       <filter name="icuFolding" />
       <filter name="synonymGraph" expand="true" ignoreCase="true" synonyms="synonyms.txt"/>
       <filter name="flattenGraph" />


### PR DESCRIPTION
Good day

Description:
This pull/merge request addresses an issue with the Solr schema configuration for the dovecot core. The schema.xml file was missing the mandatory class attribute for the standard tokenizer, causing Solr to fail when loading the configuration.

Problem
When attempting to load the dovecot core, the following error occurred:
dovecot: org.apache.solr.common.SolrException:org.apache.solr.common.SolrException: Could not load conf for core dovecot: Can't load schema /var/solr/data/dovecot/conf/schema.xml: Plugin init failure for [schema.xml] fieldType "text": Plugin init failure for [schema.xml] analyzer/tokenizer "standard": [schema.xml] analyzer/tokenizer: missing mandatory attribute 'class'

The error indicates that the standard tokenizer in the text field type is missing the required class attribute, which specifies the tokenizer's implementation class.

Solution:
The issue has been resolved by adding the class="solr.StandardTokenizerFactory" attribute to the <tokenizer> element in the schema.xml file. This ensures that Solr can correctly instantiate the standard tokenizer during core initialization.

Kind Regards
Brent Clark