### PR TITLE
Fix make dist uninstall check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,8 @@ noinst_DATA = dovecot-config
 
 nodist_pkginclude_HEADERS = config.h
 
+distuninstallcheck_listfiles = find . -type f \! -name '*.conf' -print
+
 version:
 	$(AM_V_GEN)env VERSION=$(PACKAGE_VERSION) $(top_srcdir)/build-aux/git-version-gen > $@
 

--- a/src/lib-dict-backend/Makefile.am
+++ b/src/lib-dict-backend/Makefile.am
@@ -29,6 +29,9 @@ libdict_backend_la_LIBADD =
 BUILT_SOURCES = \
 	dict-drivers-register.c
 
+DISTCLEANFILES = \
+	dict-drivers-register.c
+
 nodist_libdict_backend_la_SOURCES = \
 	dict-drivers-register.c
 


### PR DESCRIPTION
Without these to changes, my attempts to run `make distcheck` fail:

https://github.com/check-spelling-sandbox/dovecot-core/actions/runs/13380005362/job/37366794125#step:10:12764
```
ERROR: files left after uninstall:
./etc/dovecot/dovecot.conf
```

https://github.com/check-spelling-sandbox/dovecot-core/actions/runs/13380606681/job/37368401575#step:10:18167
```
ERROR: files left in build directory after distclean:
./src/lib-dict-backend/dict-drivers-register.c
```