### PR TITLE
Make solr-config-9.xml compatible with Solr 9.8.1

### DIFF
--- a/doc/solr-config-9.xml
+++ b/doc/solr-config-9.xml
@@ -37,53 +37,12 @@
   -->
   <luceneMatchVersion>9.8</luceneMatchVersion>
 
-  <!-- <lib/> directives can be used to instruct Solr to load any Jars
-       identified and use them to resolve any "plugins" specified in
-       your solrconfig.xml or schema.xml (ie: Analyzers, Request
-       Handlers, etc...).
+  <!-- You need to add enable the use of the `analysis-extras` module, by either:
 
-       All directories and paths are resolved relative to the
-       instanceDir.
-
-       Please note that <lib/> directives are processed in the order
-       that they appear in your solrconfig.xml file, and are "stacked"
-       on top of each other when building a ClassLoader - so if you have
-       plugin jars with dependencies on other jars, the "lower level"
-       dependency jars should be loaded first.
-
-       If a "./lib" directory exists in your instanceDir, all files
-       found in it are included as if you had used the following
-       syntax...
-
-              <lib dir="./lib" />
+       * modifying the "solr.modules" parameter in solr.xml to include "analysis-extras",
+         e.g. set: <str name="modules">${solr.modules:analysis-extras}</str>
+       * adding "-Dsolr.modules=analysis-extras" to the solr start command line.
     -->
-
-  <!-- A 'dir' option by itself adds any files found in the directory
-       to the classpath, this is useful for including all jars in a
-       directory.
-
-       When a 'regex' is specified in addition to a 'dir', only the
-       files in that directory which completely match the regex
-       (anchored on both ends) will be included.
-
-       If a 'dir' option (with or without a regex) is used and nothing
-       is found that matches, a warning will be logged.
-
-       The example below can be used to load a Solr Module along
-       with their external dependencies.
-    -->
-    <!-- <lib dir="${solr.install.dir:../../../..}/modules/ltr/lib" regex=".*\.jar" /> -->
-
-    <!-- Load ICU analyser -->
-    <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" regex="icu4j-.*\.jar"/>
-    <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" regex="lucene-analysis-icu-.*\.jar"/>
-  <!-- an exact 'path' can be used instead of a 'dir' to specify a
-       specific jar file.  This will cause a serious error to be logged
-       if it can't be loaded.
-    -->
-  <!--
-     <lib path="../a-jar-that-does-not-exist.jar" />
-  -->
 
   <!-- Data Directory
 
@@ -259,16 +218,9 @@
          is recommended (see below).
          "dir" - the target directory for transaction logs, defaults to the
                 solr data directory.
-         "numVersionBuckets" - sets the number of buckets used to keep
-                track of max version values when checking for re-ordered
-                updates; increase this value to reduce the cost of
-                synchronizing access to version buckets during high-volume
-                indexing, this requires 8 bytes (long) * numVersionBuckets
-                of heap space per Solr core.
     -->
     <updateLog>
       <str name="dir">${solr.ulog.dir:}</str>
-      <int name="numVersionBuckets">${solr.ulog.numVersionBuckets:65536}</int>
     </updateLog>
 
     <!-- AutoCommit


### PR DESCRIPTION
Solr 9.8.1 has one breaking change, which this commit fixes.  In Solr `<lib/>` directives have been made into an "opt-in" feature in must be explicitly enabled if desired. Unless this is done (or a better alternative is used), the dovecot provided config will fail.  See https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#configuration-2

This PR removes the `<lib/>` directives, and leaves a comment for a use to instead enable the use of Solr modules instead.  This is one of the recommended fixes by Solr.

This comment also removes the `numVersionBuckets` which is obsolete and ignored.
