### PR TITLE
build: fix fts-lib build failure

### DIFF
--- a/m4/want_icu.m4
+++ b/m4/want_icu.m4
@@ -2,11 +2,11 @@ AC_DEFUN([DOVECOT_WANT_ICU], [
   have_icu=no
 
   AS_IF([test "$want_icu" != "no"], [
-    PKG_CHECK_MODULES([LIBICU], [icu-i18n], [have_icu=yes], [
+    PKG_CHECK_MODULES([LIBICU], [icu-uc icu-i18n], [have_icu=yes], [
       have_icu=no
 
       AS_IF([test "$want_icu" = "yes"], [
-        AC_MSG_ERROR(cannot build with icu support: icu library (icu-i18n) not found)
+        AC_MSG_ERROR(cannot build with icu support: icu library (icu-uc, icu-i18n) not found)
       ])
     ])
   ])


### PR DESCRIPTION
u_strFromUTF8Lenient is in libicuuc.so.

```
$ make V=1
make  all-am
make[1]: Entering directory '~/dovecot-core/src/lib-fts'
/bin/sh ../../libtool  --tag=CC   --mode=link gcc  -std=gnu11 -O0 -g3 -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -mfunction-return=keep -mindirect-branch=keep -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2   -no-undefined -Wl,--as-needed   -o test-fts-icu test-fts-icu.o fts-icu.lo -licui18n ../lib-test/libtest.la ../lib/liblib.la
libtool: link: gcc -std=gnu11 -O0 -g3 -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -mfunction-return=keep -mindirect-branch=keep -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2 -Wl,--as-needed -o test-fts-icu test-fts-icu.o .libs/fts-icu.o  -licui18n ../lib-test/.libs/libtest.a ../lib/.libs/liblib.a -lunwind-generic -lunwind
/usr/lib64/gcc/x86_64-suse-linux/15/../../../../x86_64-suse-linux/bin/ld: .libs/fts-icu.o: undefined reference to symbol 'u_strFromUTF8Lenient_77'
/usr/lib64/gcc/x86_64-suse-linux/15/../../../../x86_64-suse-linux/bin/ld: /usr/lib64/libicuuc.so.77: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:749: test-fts-icu] Error 1
make[1]: Leaving directory '~/dovecot-core/src/lib-fts'
make: *** [Makefile:657: all] Error 2
```