### PR TITLE
build: do not modify user-provided CFLAGS variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,7 +267,7 @@ AC_C_INLINE
 LT_INIT
 
 # SIZE_MAX is missing without this
-CXXFLAGS="$CXXFLAGS -D__STDC_LIMIT_MACROS"
+AM_CXXFLAGS="$AM_CXXFLAGS -D__STDC_LIMIT_MACROS"
 
 # Use the first x.y.z numbers of the version. Also allow x.y numbering.
 AS_IF([echo "$PACKAGE_VERSION" | grep '^[[0-9]]*\.[[0-9]]*\.[[0-9]]'], [
@@ -773,8 +773,10 @@ SETTING_LINKED_FILES=`echo $libdovecot_c_files | $SED -e s,$srcdir/src,./src,g -
 AC_SUBST(SETTING_FILES)
 AC_SUBST(SETTING_LINKED_FILES)
 
-CFLAGS="$CFLAGS $EXTRA_CFLAGS"
-CXXFLAGS="$CXXFLAGS $EXTRA_CFLAGS"
+AM_CFLAGS="$AM_CFLAGS $EXTRA_CFLAGS"
+AM_CXXFLAGS="$AM_CXXFLAGS $EXTRA_CFLAGS"
+AC_SUBST([AM_CFLAGS])
+AC_SUBST([AM_CXXFLAGS])
 BINARY_LDFLAGS="$PIE_LDFLAGS $RELRO_LDFLAGS"
 BINARY_CFLAGS="$PIE_CFLAGS"
 
@@ -941,7 +943,7 @@ echo "userdbs ........ :$userdb"
 if test "$not_userdb" != ""; then
   echo "                 :$not_userdb"
 fi
-echo "CFLAGS ......... : $CFLAGS"
+echo "AM_CFLAGS ...... : $AM_CFLAGS"
 
 if test "$systemdsystemunitdir" != ""; then
   echo "SYSTEMD ........ : $systemdservicetype - $systemdsystemunitdir/dovecot.service";

--- a/m4/dovecot.m4
+++ b/m4/dovecot.m4
@@ -18,7 +18,7 @@ AC_DEFUN([AC_CC_D_FORTIFY_SOURCE],[
       case "$host" in
         *)
           gl_COMPILER_OPTION_IF([-O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2], [
-            CFLAGS="$CFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2"
+            AM_CFLAGS="$AM_CFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2"
             ],
             [],
             [AC_LANG_PROGRAM()]
@@ -43,20 +43,19 @@ AC_DEFUN([DC_DOVECOT_CFLAGS],[
     CFLAGS="-std=$mystd"
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM()
     ], [
-      CFLAGS="$CFLAGS $old_cflags"
+      AM_CFLAGS="$AM_CFLAGS $CFLAGS"
       std=$mystd
       break
-    ], [
-      CFLAGS="$old_cflags"
     ])
   done
   AC_MSG_RESULT($std)
+  CFLAGS="$old_cflags"
 
   AS_IF([test "x$ac_cv_c_compiler_gnu" = "xyes"], [
     dnl -Wcast-qual -Wcast-align -Wconversion -Wunreachable-code # too many warnings
     dnl -Wstrict-prototypes -Wredundant-decls # may give warnings in some systems
     dnl -Wmissing-format-attribute -Wmissing-noreturn -Wwrite-strings # a couple of warnings
-    CFLAGS="$CFLAGS -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast"
+    AM_CFLAGS="$AM_CFLAGS -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast"
 
     AS_IF([test "$have_clang" = "yes"], [
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -65,11 +64,11 @@ AC_DEFUN([DC_DOVECOT_CFLAGS],[
       #endif
       ]], [[]])],[],[
         dnl clang 3.3+ unfortunately this gives warnings with hash.h
-        CFLAGS="$CFLAGS -Wno-duplicate-decl-specifier"
+        AM_CFLAGS="$AM_CFLAGS -Wno-duplicate-decl-specifier"
       ])
     ], [
       dnl This is simply to avoid warning when building strftime() wrappers..
-      CFLAGS="$CFLAGS -fno-builtin-strftime"
+      AM_CFLAGS="$AM_CFLAGS -fno-builtin-strftime"
     ])
 
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
@@ -78,7 +77,7 @@ AC_DEFUN([DC_DOVECOT_CFLAGS],[
       #endif
       ]], [[]])],[
         dnl gcc4
-        CFLAGS="$CFLAGS -Wstrict-aliasing=2"
+        AM_CFLAGS="$AM_CFLAGS -Wstrict-aliasing=2"
       ],[])
   ])
 ])
@@ -210,12 +209,12 @@ AC_DEFUN([AC_CC_RETPOLINE],[
       case "$host" in
         *)
           gl_COMPILER_OPTION_IF([-mfunction-return=$with_retpoline],
-            [CFLAGS="$CFLAGS -mfunction-return=$with_retpoline"],
+            [AM_CFLAGS="$AM_CFLAGS -mfunction-return=$with_retpoline"],
             [],
             [AC_LANG_PROGRAM()]
           )
           gl_COMPILER_OPTION_IF([-mindirect-branch=$with_retpoline], [
-            CFLAGS="$CFLAGS -mindirect-branch=$with_retpoline"
+            AM_CFLAGS="$AM_CFLAGS -mindirect-branch=$with_retpoline"
             ],
             [],
             [AC_LANG_PROGRAM()]
@@ -234,11 +233,11 @@ AC_DEFUN([AC_CC_F_STACK_PROTECTOR],[
       case "$host" in
         *)
           gl_COMPILER_OPTION_IF([-fstack-protector-strong], [
-            CFLAGS="$CFLAGS -fstack-protector-strong"
+            AM_CFLAGS="$AM_CFLAGS -fstack-protector-strong"
             ],
             [
                gl_COMPILER_OPTION_IF([-fstack-protector], [
-                 CFLAGS="$CFLAGS -fstack-protector"
+                 AM_CFLAGS="$AM_CFLAGS -fstack-protector"
                  ], [], [AC_LANG_PROGRAM()])
             ],
             [AC_LANG_PROGRAM()]
@@ -310,7 +309,7 @@ AC_DEFUN([DC_DOVECOT_FUZZER],[
                 with_fuzzer=$withval,
                 with_fuzzer=no)
 	AS_IF([test x$with_fuzzer = xclang], [
-		CFLAGS="$CFLAGS -fsanitize=fuzzer-no-link"
+		AM_CFLAGS="$AM_CFLAGS -fsanitize=fuzzer-no-link"
 		# use $LIB_FUZZING_ENGINE for linking if it exists
 		FUZZER_LDFLAGS=${LIB_FUZZING_ENGINE--fsanitize=fuzzer}
 		# May need to use CXXLINK for linking, which wants sources to

--- a/src/config/Makefile.am
+++ b/src/config/Makefile.am
@@ -102,7 +102,7 @@ test_libs = \
 	$(noinst_LTLIBRARIES) \
 	$(LIBDOVECOT)
 
-test_config_parser_CFLAGS = $(AM_CPPFLAGS)
+test_config_parser_CFLAGS = $(AM_CFLAGS)
 test_config_parser_SOURCES = test-config-parser.c
 test_config_parser_LDADD = $(test_libs)
 test_config_parser_DEPENDENCIES = $(LIBDOVECOT_DEPS) $(noinst_LTLIBRARIES)

--- a/src/lib-dcrypt/Makefile.am
+++ b/src/lib-dcrypt/Makefile.am
@@ -15,14 +15,13 @@ libdcrypt_la_SOURCES = \
 	istream-decrypt.c \
 	ostream-encrypt.c
 
-libdcrypt_la_CFLAGS = $(AM_CPPFLAGS)
+libdcrypt_la_CFLAGS = $(AM_CFLAGS)
 
 libdcrypt_openssl_static_la_SOURCES = dcrypt-openssl1.c dcrypt-openssl3.c
 libdcrypt_openssl_static_la_LDFLAGS = ../lib-ssl-iostream/libssl_iostream_openssl.la
 libdcrypt_openssl_static_la_LIBADD = $(SSL_LIBS)
 libdcrypt_openssl_static_la_DEPENDENCIES = ../lib-ssl-iostream/libssl_iostream_openssl.la
-libdcrypt_openssl_static_la_CFLAGS = $(AM_CPPFLAGS) \
-	$(SSL_CFLAGS)
+libdcrypt_openssl_static_la_CFLAGS = $(AM_CFLAGS) $(SSL_CFLAGS)
 
 module_LTLIBRARIES += libdcrypt_openssl.la
 
@@ -30,8 +29,7 @@ libdcrypt_openssl_la_SOURCES = dcrypt-openssl1.c dcrypt-openssl3.c
 libdcrypt_openssl_la_LDFLAGS = -module -avoid-version ../lib-ssl-iostream/libssl_iostream_openssl.la
 libdcrypt_openssl_la_LIBADD = $(SSL_LIBS)
 libdcrypt_openssl_la_DEPENDENCIES = ../lib-ssl-iostream/libssl_iostream_openssl.la
-libdcrypt_openssl_la_CFLAGS = $(AM_CPPFLAGS) \
-	$(SSL_CFLAGS)
+libdcrypt_openssl_la_CFLAGS = $(AM_CFLAGS) $(SSL_CFLAGS)
 
 headers = \
 	dcrypt.h \
@@ -73,7 +71,7 @@ test_crypto_DEPENDENCIES = $(LIBDOVECOT_TEST_DEPS)
 if HAVE_WHOLE_ARCHIVE
 test_crypto_LDFLAGS = -export-dynamic -Wl,$(LD_WHOLE_ARCHIVE),../lib-var-expand/.libs/libvar_expand.a,../lib/.libs/liblib.a,../lib-json/.libs/libjson.a,../lib-ssl-iostream/.libs/libssl_iostream.a,$(LD_NO_WHOLE_ARCHIVE)
 endif
-test_crypto_CFLAGS = $(AM_CPPFLAGS) -DDCRYPT_SRC_DIR=\"$(top_srcdir)/src/lib-dcrypt\"
+test_crypto_CFLAGS = $(AM_CFLAGS) -DDCRYPT_SRC_DIR=\"$(top_srcdir)/src/lib-dcrypt\"
 test_crypto_SOURCES = $(libdcrypt_la_SOURCES) test-crypto.c
 
 test_stream_LDADD = $(LIBDOVECOT_TEST)
@@ -81,5 +79,5 @@ test_stream_DEPENDENCIES = $(LIBDOVECOT_TEST_DEPS)
 if HAVE_WHOLE_ARCHIVE
 test_stream_LDFLAGS = -export-dynamic -Wl,$(LD_WHOLE_ARCHIVE),../lib-var-expand/.libs/libvar_expand.a,../lib/.libs/liblib.a,../lib-json/.libs/libjson.a,../lib-ssl-iostream/.libs/libssl_iostream.a,$(LD_NO_WHOLE_ARCHIVE)
 endif
-test_stream_CFLAGS = $(AM_CPPFLAGS) -DDCRYPT_SRC_DIR=\"$(top_srcdir)/src/lib-dcrypt\"
+test_stream_CFLAGS = $(AM_CFLAGS) -DDCRYPT_SRC_DIR=\"$(top_srcdir)/src/lib-dcrypt\"
 test_stream_SOURCES = $(libdcrypt_la_SOURCES) test-stream.c

--- a/src/lib-dict-backend/Makefile.am
+++ b/src/lib-dict-backend/Makefile.am
@@ -46,7 +46,7 @@ LIBDICT_LDAP = libdict_ldap.la
 libdict_ldap_la_DEPENDENCIES = $(LIBDOVECOT_LDAP) $(LIBDOVECOT_DEPS)
 libdict_ldap_la_LDFLAGS = -module -avoid-version
 libdict_ldap_la_LIBADD = $(LIBDOVECOT_LDAP) $(LIBDOVECOT)
-libdict_ldap_la_CPPFLAGS = $(AM_CPPFLAGS) -DPLUGIN_BUILD
+libdict_ldap_la_CPPFLAGS = $(AM_CFLAGS) -DPLUGIN_BUILD
 libdict_ldap_la_SOURCES = $(ldap_sources)
 else
 if HAVE_LDAP
@@ -97,7 +97,7 @@ test_programs = \
 
 noinst_PROGRAMS = $(test_programs)
 
-test_dict_sql_CFLAGS = $(AM_CPPFLAGS) -DDICT_SRC_DIR=\"$(top_srcdir)/src/lib-dict-backend\"
+test_dict_sql_CFLAGS = $(AM_CFLAGS) -DDICT_SRC_DIR=\"$(top_srcdir)/src/lib-dict-backend\"
 test_dict_sql_SOURCES = \
 	test-dict-sql.c
 test_dict_sql_LDADD = \

--- a/src/lib-lua/Makefile.am
+++ b/src/lib-lua/Makefile.am
@@ -71,7 +71,7 @@ noinst_PROGRAMS = $(test_programs)
 test_libs_ssl = ../lib-ssl-iostream/libssl_iostream_openssl.la
 
 test_lua_SOURCES = test-lua.c
-test_lua_CFLAGS = $(AM_CPPFLAGS) $(BINARY_CFLAGS)
+test_lua_CFLAGS = $(AM_CFLAGS) $(BINARY_CFLAGS)
 test_lua_LDFLAGS = $(BINARY_LDFLAGS)
 test_lua_LDADD = libdlua.la $(LIBDOVECOT) $(LUA_LIBS)
 test_lua_DEPENDENCIES = libdlua.la $(LIBDOVECOT_DEPS)
@@ -92,7 +92,7 @@ test_lua_http_client_SOURCES = test-lua-http-client.c
 test_lua_http_client_LDADD = libdlua.la $(LIBDOVECOT) $(test_libs_ssl) $(LUA_LIBS)
 test_lua_http_client_DEPENDENCIES = libdlua.la $(LIBDOVECOT_DEPS)
 test_lua_http_client_CFLAGS = \
-	$(AM_CPPFLAGS) \
+	$(AM_CFLAGS) \
 	$(DOVECOT_BINARY_CFLAGS) \
 	-DTEST_LUA_SCRIPT_DIR=\"$(abs_top_srcdir)/src/lib-lua\"
 

--- a/src/lib-var-expand-crypt/Makefile.am
+++ b/src/lib-var-expand-crypt/Makefile.am
@@ -36,7 +36,7 @@ if HAVE_WHOLE_ARCHIVE
 test_var_expand_crypt_LDFLAGS = -export-dynamic -Wl,$(LD_WHOLE_ARCHIVE),../lib/.libs/liblib.a,../lib-json/.libs/libjson.a,../lib-ssl-iostream/.libs/libssl_iostream.a,$(LD_NO_WHOLE_ARCHIVE)
 endif
 
-test_var_expand_crypt_CFLAGS = $(AM_CPPFLAGS) \
+test_var_expand_crypt_CFLAGS = $(AM_CFLAGS) \
 	-DDCRYPT_BUILD_DIR=\"$(top_builddir)/src/lib-dcrypt\"
 
 check-local:

--- a/src/plugins/mail-crypt/Makefile.am
+++ b/src/plugins/mail-crypt/Makefile.am
@@ -78,7 +78,7 @@ test_fs_crypt_DEPENDENCIES = $(LIBDOVECOT_DEPS) \
 	fs-crypt.lo \
 	mail-crypt-global-key.lo
 test_fs_crypt_LDFLAGS = $(DOVECOT_BINARY_LDFLAGS)
-test_fs_crypt_CFLAGS = $(AM_CPPFLAGS) $(DOVECOT_BINARY_CFLAGS) -Dtop_builddir=\"$(top_builddir)\"
+test_fs_crypt_CFLAGS = $(AM_CFLAGS) $(DOVECOT_BINARY_CFLAGS) -Dtop_builddir=\"$(top_builddir)\"
 
 test_mail_global_key_SOURCES = \
 	test-mail-global-key.c \
@@ -87,7 +87,7 @@ test_mail_global_key_SOURCES = \
 test_mail_global_key_LDADD = $(LIBDOVECOT)
 test_mail_global_key_DEPENDENCIES = $(LIBDOVECOT_DEPS)
 test_mail_global_key_LDFLAGS = $(DOVECOT_BINARY_LDFLAGS)
-test_mail_global_key_CFLAGS = $(AM_CPPFLAGS) $(DOVECOT_BINARY_CFLAGS) -Dtop_builddir=\"$(top_builddir)\"
+test_mail_global_key_CFLAGS = $(AM_CFLAGS) $(DOVECOT_BINARY_CFLAGS) -Dtop_builddir=\"$(top_builddir)\"
 
 test_mail_key_SOURCES = \
 	test-mail-key.c \
@@ -98,7 +98,7 @@ test_mail_key_SOURCES = \
 test_mail_key_LDADD = $(LIBDOVECOT_STORAGE) $(LIBDOVECOT)
 test_mail_key_DEPENDENCIES = $(LIBDOVECOT_DEPS)  $(LIBDOVECOT_STORAGE_DEPS)
 test_mail_key_LDFLAGS = $(DOVECOT_BINARY_LDFLAGS)
-test_mail_key_CFLAGS = $(AM_CPPFLAGS) $(DOVECOT_BINARY_CFLAGS) -Dtop_builddir=\"$(top_builddir)\"
+test_mail_key_CFLAGS = $(AM_CFLAGS) $(DOVECOT_BINARY_CFLAGS) -Dtop_builddir=\"$(top_builddir)\"
 
 noinst_HEADERS = \
 	crypt-settings.h \

--- a/src/plugins/push-notification/Makefile.am
+++ b/src/plugins/push-notification/Makefile.am
@@ -74,7 +74,7 @@ pkginc_libdir = $(pkgincludedir)
 pkginc_lib_HEADERS = $(headers)
 
 if HAVE_LUA
-lib22_push_notification_lua_plugin_la_CFLAGS = $(AM_CPPFLAGS) \
+lib22_push_notification_lua_plugin_la_CFLAGS = $(AM_CFLAGS) \
 	-I$(top_srcdir)/src/lib-lua \
 	-I$(top_srcdir)/src/plugins/mail-lua \
 	$(LUA_CFLAGS)


### PR DESCRIPTION
```
$ ./configure CFLAGS="-U_FORTIFY_SOURCE -g3" && grep ^CFLAGS Makefile && make
...
CFLAGS = -std=gnu11 -U_FORTIFY_SOURCE -g3 -U_FORTIFY_SOURCE -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -mfunction-return=keep -mindirect-branch=keep -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2
...
/usr/include/features.h:435:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  435 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
```

This is not how `./configure CFLAGS=...` should work. As per https://www.gnu.org/software/automake/manual/html_node/User-Variables.html CFLAGS is reserved for the user, should not be changed (and also should enjoy highest precedence).

AM_CFLAGS is the right variable to use here.