### PR TITLE
Problem with Dovecot on a FIPS enabled system

### DIFF
--- a/src/lib-dcrypt/dcrypt-openssl3.c
+++ b/src/lib-dcrypt/dcrypt-openssl3.c
@@ -2679,7 +2679,7 @@ dcrypt_openssl_encrypt_private_key_dovecot(buffer_t *key, int enctype,
 	bool res;
 	unsigned char *ptr;
 
-	unsigned char salt[8];
+	unsigned char salt[16];
 	buffer_t *peer_key = t_buffer_create(128);
 	buffer_t *secret = t_buffer_create(128);
 	cipher = t_str_lcase(cipher);

--- a/src/plugins/mail-crypt/doveadm-mail-crypt.c
+++ b/src/plugins/mail-crypt/doveadm-mail-crypt.c
@@ -692,7 +692,7 @@ static void cmd_mcp_key_export_cb(const struct generated_key *key,
 		doveadm_print(t_strdup_printf("ERROR: %s", error));
 		doveadm_print("");
 	} else {
-		string_t *out = t_str_new(64);
+		string_t *out = t_str_new(128);
 		if (!dcrypt_key_store_private(pkey, DCRYPT_FORMAT_PEM, NULL, out,
 					      NULL, NULL, &error)) {
 			doveadm_print(t_strdup_printf("ERROR: %s", error));


### PR DESCRIPTION
This pull request updates the salt when encrypting a mailbox to 16 bytes to be FIPS compliant.

This bug was submitted on an Ubuntu Jammy system with FIPS enabled. Here is the Ubuntu bug report:
https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/2107773

[ Impact ]
* When one enables FIPS mode on a Jammy system and then attempts to use Dovecot to create an encrypted mailbox, the module returns a invalid salt length error.

* FIPS mode requires a 16 byte salt for PBEKDF2 and Dovecot is only requesting 8 bytes of salt. The solution is to modify Dovecot to request 16 bytes of salt.

[ Test Plan ]

* Install Dovecot on the system
  - sudo apt install dovecot-auth-lua dovecot-core dovecot-gssapi dovecot-imapd dovecot-ldap dovecot-lmtpd dovecot-managesieved dovecot-mysql dovecot-pgsql dovecot-pop3d dovecot-sieve dovecot-solr dovecot-sqlite dovecot-submissiond
* Enable mailbox encryption.
  - Add /etc/dovecot/conf.d//mail-crypt.conf to enable mailbox encryption: mail_location = mbox:~/mail:INBOX=/var/mail/%u
listen = *
mbox_write_locks = fcntl
namespace inbox {
  inbox = yes
  location =
  mailbox Drafts {
    special_use = \Drafts }

  mailbox Junk {
    special_use = \Junk } mailbox Sent { special_use = \Sent } mailbox "Sent Messages" { special_use = \Sent } mailbox Trash { special_use = \Trash } prefix = }
passdb {
  driver = pam
}
userdb {
  driver = passwd
}

mail_plugins = $mail_plugins mail_crypt

plugin {
  mail_crypt_curve = secp521r1
  mail_crypt_save_version=2
}

mail_attribute_dict = file:%h/Maildir/dovecot-attributes imap_metadata = yes

* Issue the following command to create an encrypted mailbox:
  - sudo doveadm -o plugin/mail_crypt_private_password=e32f1f174d7576716d5df899e7d5cb6b64cdb33584c71882e9f7e1f79f2e695e mailbox cryptokey generate -u <username>

* Verify that no error occurs.

* Enable FIPS on a Jammy system.
  - sudo pro attach <token>
  - sudo pro enable fips-updates
  - sudo reboot (To test FIPS on a Noble system)
  - sudo add-apt-repository ppa:fips-cc-stig/fips-under-certification
  - sudo apt install -y ubuntu-fips openssh-server=1:9.6p1-3ubuntu13+Fips1~rc0 \ openssh-client=1:9.6p1-3ubuntu13+Fips1~rc0 \ openssh-sftp-server=1:9.6p1-3ubuntu13+Fips1~rc0 \ --allow-downgrades --yes

* Reboot

* Delete the mailbox
  - rm -rf ~/mail

* Issue the following command to create an encrypted mailbox:
  - sudo doveadm -o plugin/mail_crypt_private_password=e32f1f174d7576716d5df899e7d5cb6b64cdb33584c71882e9f7e1f79f2e695e mailbox cryptokey generate -u <username>

* Verify that an error occurs.

* Update Dovecot to the fixed version.

* Repeat the commands to delete the mailbox and to create an encrypted mailbox.

* After installing the fix, verify that no error occurs.

[ Where problems could occur ]

* The increased salt size of 16 bytes could potentially cause issues in allocated data structures, but I've attempted to mitigate this by increasing the size of potentially problematic data structures.

[ Other Info ]

This is really only needed on systems where FIPS is supported, i.e. Jammy and Noble and 26.04.