### PR TITLE
lib: cpu-count - fix compilation using musl

### DIFF
--- a/src/lib/cpu-count.c
+++ b/src/lib/cpu-count.c
@@ -3,6 +3,8 @@
 
 #ifdef HAVE_SCHED_H
 #  define __USE_GNU
+/* _GNU_SOURCE: for musl's sched.h to expose cpuset/CPU_* */
+#  define _GNU_SOURCE
 #  include <sched.h>
 #  ifdef HAVE_SYS_CPUSET_H
 #    include <sys/cpuset.h>


### PR DESCRIPTION
The macros, types and symbols CPU_* and cpu_set_t are not exposed in musl's sched.h unless _GNU_SOURCE is set.

Without this compilation dies:
```
x86_64-pc-linux-musl-gcc -DHAVE_CONFIG_H -I. -I../.. -std=gnu11 -O3 -march=native -pipe -fasynchronous-unwind-tables -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wchar-subscripts -Wformat=2 -Wbad-function-cast -fno-builtin-strftime -Wstrict-aliasing=2 -c cpu-count.c -fPIC -DPIC -o .libs/cpu-count.o
cpu-count.c: In function 'cpu_count_get':
cpu-count.c:17:9: error: unknown type name 'cpu_set_t'
   17 |         cpu_set_t cs;
      |         ^~~~~~~~~
cpu-count.c:18:9: error: implicit declaration of function 'CPU_ZERO' [-Wimplicit-function-declaration]
   18 |         CPU_ZERO(&cs);
      |         ^~~~~~~~
cpu-count.c:19:13: error: implicit declaration of function 'sched_getaffinity'  -Wimplicit-function-declaration]
   19 |         if (sched_getaffinity(0, sizeof(cs), &cs) < 0) {
      |             ^~~~~~~~~~~~~~~~~
cpu-count.c:23:18: error: implicit declaration of function 'CPU_COUNT'; did you mean 'CPU_COUNT_H'? [-Wimplicit-function-declaration]
   23 |         result = CPU_COUNT(&cs);
      |                  ^~~~~~~~~
      |                  CPU_COUNT_H
```