### PR TITLE
lib-index: Fix storing cache fields' last_used with 32bit big endian CPUs

### DIFF
--- a/src/lib-index/mail-cache-fields.c
+++ b/src/lib-index/mail-cache-fields.c
@@ -569,11 +569,12 @@ static void
 copy_to_buf_last_used(struct mail_cache *cache, buffer_t *dest, bool add_new)
 {
 	size_t offset = offsetof(struct mail_cache_field, last_used);
-#if defined(WORDS_BIGENDIAN) && SIZEOF_VOID_P == 8
+#if defined(WORDS_BIGENDIAN)
 	/* 64bit time_t with big endian CPUs: copy the last 32 bits instead of
 	   the first 32 bits (that are always 0). The 32 bits are enough until
 	   year 2106, so we're not in a hurry to use 64 bits on disk. */
-	offset += sizeof(uint32_t);
+	if (sizeof(time_t) >= sizeof(uint32_t))
+		offset += sizeof(uint32_t);
 #endif
 	copy_to_buf(cache, dest, add_new, offset, sizeof(uint32_t));
 }


### PR DESCRIPTION
Debian started in 2025 to build packages on 32-bit platforms with 64-bit time_t support by default. With that change, dovecot suddenly fails to build on 32-bit big endian architectures (e.g. hppa, powerpc) with those testsuite errors:

test-mail-cache-fields.c:52: Assert failed: cache_field.last_used == priv->field.last_used && cache_field.decision == priv->field.decision
test-mail-cache-fields.c:67: Assert failed: cache_field.last_used == priv->field.last_used && cache_field.decision == priv->field.decision
test-mail-cache-fields.c:96: Assert failed: cache_field.last_used == priv->field.last_used && cache_field.decision == priv->field.decision
mail cache fields read-write ......................................... : FAILED

Change the existing code for big endian architectures to actually check the size of time_t at compile time instead of hardcoding a check for SIZEOF_VOID_P to fix the issue for 32- and 64-bit big endian architectures.

Cc: Timo Sirainen <timo.sirainen@open-xchange.com>
Fixes: 1ee84ba0659f ("lib-index: Fix storing cache fields' last_used with 64bit big endian CPUs")