### PR TITLE
global: More fixes for compiling without LDAP

### DIFF
--- a/src/auth/Makefile.am
+++ b/src/auth/Makefile.am
@@ -130,8 +130,12 @@ auth_common_sources = \
 	userdb-prefetch.c \
 	userdb-static.c \
 	userdb-sql.c \
+if HAVE_LDAP
 	$(ldap_sources) \
+endif
+if HAVE_LUA
 	$(lua_sources)
+endif
 
 headers = \
 	auth.h \
@@ -226,7 +230,9 @@ test_auth_SOURCES = \
 	test-auth-request-var-expand.c \
 	test-auth-request-fields.c \
 	test-username-filter.c \
+if HAVE_LUA
 	test-lua.c \
+endif
 	test-mock.c \
 	test-main.c
 

--- a/src/auth/passdb.c
+++ b/src/auth/passdb.c
@@ -253,12 +253,14 @@ passdb_result_to_string(enum passdb_result result)
 
 extern struct passdb_module_interface passdb_passwd;
 extern struct passdb_module_interface passdb_bsdauth;
-#ifdef HAVE_LUA
+#ifdef AUTH_LUA_PLUGIN
 extern struct passdb_module_interface passdb_lua;
 #endif
 extern struct passdb_module_interface passdb_passwd_file;
 extern struct passdb_module_interface passdb_pam;
+#ifdef LDAP_PLUGIN
 extern struct passdb_module_interface passdb_ldap;
+#endif
 extern struct passdb_module_interface passdb_sql;
 extern struct passdb_module_interface passdb_static;
 extern struct passdb_module_interface passdb_oauth2;
@@ -269,12 +271,14 @@ void passdbs_init(void)
 	i_array_init(&passdb_modules, 16);
 	passdb_register_module(&passdb_passwd);
 	passdb_register_module(&passdb_bsdauth);
-#ifdef HAVE_LUA
+#ifdef AUTH_LUA_PLUGIN
 	passdb_register_module(&passdb_lua);
 #endif
 	passdb_register_module(&passdb_passwd_file);
 	passdb_register_module(&passdb_pam);
+#ifdef LDAP_PLUGIN
 	passdb_register_module(&passdb_ldap);
+#endif
 	passdb_register_module(&passdb_sql);
 	passdb_register_module(&passdb_static);
 	passdb_register_module(&passdb_oauth2);

--- a/src/auth/userdb.c
+++ b/src/auth/userdb.c
@@ -176,9 +176,11 @@ extern struct userdb_module_interface userdb_prefetch;
 extern struct userdb_module_interface userdb_static;
 extern struct userdb_module_interface userdb_passwd;
 extern struct userdb_module_interface userdb_passwd_file;
+#ifdef LDAP_PLUGIN
 extern struct userdb_module_interface userdb_ldap;
+#endif
 extern struct userdb_module_interface userdb_sql;
-#ifdef HAVE_LUA
+#ifdef AUTH_LUA_PLUGIN
 extern struct userdb_module_interface userdb_lua;
 #endif
 
@@ -190,9 +192,11 @@ void userdbs_init(void)
 	userdb_register_module(&userdb_passwd_file);
 	userdb_register_module(&userdb_prefetch);
 	userdb_register_module(&userdb_static);
+#ifdef LDAP_PLUGIN
 	userdb_register_module(&userdb_ldap);
+#endif
 	userdb_register_module(&userdb_sql);
-#ifdef HAVE_LUA
+#ifdef AUTH_LUA_PLUGIN
 	userdb_register_module(&userdb_lua);
 #endif
 }


### PR DESCRIPTION
I discovered that Dovecot 2.4.0 would not build without ldap.h while trying to update OpenWrt's Dovecot package. I found commit 61fe6bbd, but it appeared incomplete after I backported it. I think there are still some conditionals that need to be added to the build system.

This commit adds a few more conditionals. There is still a problem with `all-settings.c` unconditionally including ldap.h, but I don't yet understand `settings-get.pl` enough to fix this.

Additionally, it might be possible to simplify things, both with my changes and the existing build definitions.

Though incomplete, I hoped this patch would help make progress.