### PR TITLE
Use filename string duplicate for settings to avoid crash on leaked settings

### DIFF
--- a/src/lib-settings/settings.c
+++ b/src/lib-settings/settings.c
@@ -1517,7 +1517,7 @@ settings_mmap_pool_create(struct settings_root *root,
 	mpool->parent_pool = parent_pool;
 	mpool->root = root;
 	mpool->mmap = mmap;
-	mpool->source_filename = source_filename;
+	mpool->source_filename = p_strdup(parent_pool, source_filename);
 	mpool->source_linenum = source_linenum;
 	if (mmap != NULL)
 		settings_mmap_ref(mmap);


### PR DESCRIPTION
The crash happens in [settings_root_deinit](https://github.com/dovecot/core/blob/main/src/lib-settings/settings.c#L3254-L3275):
```C
	for (mpool = root->settings_pools; mpool != NULL; mpool = mpool->next) {
		i_warning("Leaked settings: %s:%u",
			  mpool->source_filename, mpool->source_linenum);
	}
```
because we are trying to read from pointer that was already dropped.