### PR TITLE
quota: Fix maildir quota drop to zero after IMAP MOVE

### DIFF
--- a/src/plugins/quota/quota-private.h
+++ b/src/plugins/quota/quota-private.h
@@ -165,6 +165,11 @@ struct quota_transaction_context {
 	bool auto_updating:1;
 	/* Quota doesn't need to be updated within this transaction. */
 	bool no_quota_updates:1;
+	/* TRUE if this transaction is for an IMAP MOVE operation. Used by
+	   quota_try_alloc() to avoid double-counting the expunged source
+	   mail: quota_mail_expunge() already accounts for it in the source
+	   transaction via quota_free_bytes(). */
+	bool moving:1;
 };
 
 void quota_add_user_namespace(struct quota *quota, const char *root_name,

--- a/src/plugins/quota/quota-storage.c
+++ b/src/plugins/quota/quota-storage.c
@@ -255,6 +255,7 @@ static int quota_check(struct mail_save_context *ctx)
 	if (qt->failed)
 		return 0;
 
+	qt->moving = ctx->moving;
 	const char *error;
 	ret = quota_try_alloc(qt, ctx->dest_mail, ctx->expunged_mail,
 			      NULL, &error);

--- a/src/plugins/quota/quota.c
+++ b/src/plugins/quota/quota.c
@@ -1180,7 +1180,14 @@ quota_try_alloc(struct quota_transaction_context *ctx,
 	   quota_alloc() or quota_free_bytes() was already used within the same
 	   transaction, but that doesn't normally happen. */
 	ctx->auto_updating = FALSE;
-	quota_alloc_with_size(ctx, size, expunged_size);
+	/* For IMAP MOVE, do not subtract expunged_size here: the source mail
+	   expunge is already accounted for by quota_mail_expunge() ->
+	   quota_free_bytes() in the source transaction.  Subtracting it here
+	   too causes double-counting (destination records bytes_used=0, source
+	   records bytes_used=-size, net result: quota drops by size).
+	   expunged_size is still passed to quota_test_alloc() above so that
+	   moves at the quota boundary are correctly permitted. */
+	quota_alloc_with_size(ctx, size, ctx->moving ? 0 : expunged_size);
 	return QUOTA_ALLOC_RESULT_OK;
 }
 


### PR DESCRIPTION
## Problem

When `mailbox_move()` is called with the `maildir` quota driver, the source
mail's expunge is double-counted, causing reported quota to drop to **0** after
any IMAP MOVE operation.

### Symptom

```
# Before move – correct
$ doveadm quota get -u user@example.com
Quota name  Type     Value  Limit   %
user        STORAGE   1387   5120  27

# After IMAP MOVE to another folder – broken
$ doveadm quota get -u user@example.com
Quota name  Type     Value  Limit   %
user        STORAGE      0   5120   0
```

The message physically exists in the destination folder; only the quota tracking
is wrong. The `maildirsize` file accumulates an unbalanced negative delta with no
corresponding positive entry.

## Root Cause

Two separate code paths both account for the source mail's expunge:

**1. Destination transaction** — `quota_save_finish` → `quota_check` →
`quota_try_alloc`:

```c
quota_alloc_with_size(ctx, size=N, expunged_size=N);
//   ctx->bytes_used += N    (save to destination)
//   ctx->bytes_used -= N    (quota_used_apply_expunged subtracts expunged_size)
//   net: ctx->bytes_used = 0  → nothing written to maildirsize
```

**2. Source transaction** — `mail_expunge` → `quota_mail_expunge` →
`quota_free_bytes`:

```c
// Always fires, regardless of ctx->moving
src_qt->bytes_used -= N;   // → writes "-N -1" to maildirsize
```

Result: `maildirsize` receives only the negative delta; the positive entry for
the destination is never written.

## Fix

Add a `moving` flag to `quota_transaction_context`. It is set from
`mail_save_context.moving` in `quota_check()`. In `quota_try_alloc()`, pass
`expunged_size=0` to `quota_alloc_with_size()` when `ctx->moving` is `TRUE`.

`expunged_size` remains unchanged in the `quota_test_alloc()` call, so moves at
the quota boundary are still correctly permitted. The actual accounting for the
source expunge continues to be handled by the source transaction's
`quota_mail_expunge()` -> `quota_free_bytes()` path.

After the fix:

| Transaction | bytes_used | Written to maildirsize |
|---|---|---|
| Destination | +N | `+N +1` |
| Source      | -N | `-N -1` |
| Net         |  0 | correct |

## Testing

Reproduce with the `maildir` quota driver:

```bash
doveadm quota recalc -u user@example.com
doveadm move -u user@example.com INBOX.Drafts mailbox INBOX ALL
doveadm quota get -u user@example.com   # was 0 before this fix
```

COPY + EXPUNGE is unaffected (the `moving` flag remains `FALSE` in that path).

## Files changed

- `src/plugins/quota/quota-private.h` — add `moving:1` bitfield to
  `quota_transaction_context`
- `src/plugins/quota/quota-storage.c` — propagate `ctx->moving` into the quota
  transaction in `quota_check()`
- `src/plugins/quota/quota.c` — skip subtracting `expunged_size` from
  `bytes_used` in `quota_try_alloc()` when the transaction is a MOVE
