### PR TITLE
maildirfolder incorrectly created in INBOX root when CREATE INBOX is issued

### DIFF
--- a/src/lib-storage/index/maildir/maildir-storage.c
+++ b/src/lib-storage/index/maildir/maildir-storage.c
@@ -518,6 +518,11 @@ static int maildir_create_maildirfolder_file(struct mailbox *box)
 	   all subfolders. Do this only with Maildir++ layout. */
 	if (strcmp(box->list->name, MAILBOX_LIST_NAME_MAILDIRPLUSPLUS) != 0)
 		return 0;
+
+	/* INBOX root is not a child Maildir; the marker breaks quota et al. */
+	if (box->inbox_any)
+		return 0;
+
 	perm = mailbox_get_permissions(box);
 
 	path = t_strconcat(mailbox_get_path(box),


### PR DESCRIPTION
### Description

When an IMAP client issues `CREATE INBOX`, Dovecot correctly returns:
` NO [ALREADYEXISTS] Mailbox already exists `

However, even on failure, Dovecot still creates (or attempts to create) a `maildirfolder` file in the INBOX Maildir root.

This is incorrect for Maildir++ semantics: `maildirfolder` is intended only for sub-mailboxes, not the root. Its presence in INBOX breaks quota handling (`maildirsize`) and can cause incorrect usage reporting.

### Steps to reproduce

```
telnet localhost 143
a login user@example.com password
a create INBOX
a logout
```

Check:
```
Maildir/maildirfolder
```

##### Observed

* [ALREADYEXISTS] is returned
* Filesystem is still modified
* maildirfolder appears in INBOX root
* Quota may return incorrect values (e.g. 0)

##### Expected

* CREATE INBOX must not modify filesystem
* maildirfolder must never exist in Maildir root
* No side effects on existing mailbox

### Cause

index_storage_mailbox_create() may return 1 even when mailbox already exists, causing maildir_mailbox_create() to proceed and call:
```
maildir_create_maildirfolder_file()
```

This happens unconditionally for Maildir++.

### Proposed fix

Skip creation for INBOX:
```
if (box->inbox_any) 
    return 0; 
```

### Impact
* Breaks quota (maildirsize)
* Invalid Maildir state
* Triggered by any IMAP client issuing CREATE INBOX

### Workaround
* Remove maildirfolder from Maildir root
* Avoid CREATE INBOX from clients/scripts