### PR TITLE
Add integer overflow checks to p_strarray_dup and new test for large …

### DIFF
--- a/src/lib/strfuncs.c
+++ b/src/lib/strfuncs.c
@@ -962,9 +962,14 @@ const char **p_strarray_dup(pool_t pool, const char *const *arr)
 	char *p;
 	size_t len, size = sizeof(const char *);
 
-	/* @UNSAFE: integer overflow checks are missing */
-	for (i = 0; arr[i] != NULL; i++)
-		size += sizeof(const char *) + strlen(arr[i]) + 1;
+	for (i = 0; arr[i] != NULL; i++) {
+		len = strlen(arr[i]) + 1;
+		/* Check for integer overflow before accumulation */
+		if (len > SIZE_MAX - sizeof(const char *) ||
+		    size > SIZE_MAX - (sizeof(const char *) + len))
+			i_panic("p_strarray_dup(): size overflow");
+		size += sizeof(const char *) + len;
+	}
 
 	ret = p_malloc(pool, size);
 	p = PTR_OFFSET(ret, sizeof(const char *) * (i + 1));

--- a/src/lib/test-strfuncs.c
+++ b/src/lib/test-strfuncs.c
@@ -104,6 +104,26 @@ static void test_p_strarray_dup(void)
 	test_end();
 }
 
+static void test_p_strarray_dup_large_inputs(void)
+{
+	const char *arr[1000];
+	unsigned int i;
+
+	test_begin("p_strarray_dup() large inputs");
+
+	for (i = 0; i < 999; i++)
+		arr[i] = "test";
+	arr[999] = NULL;
+
+	const char **ret = p_strarray_dup(default_pool, arr);
+	for (i = 0; i < 999; i++)
+		test_assert(strcmp(ret[i], "test") == 0);
+	test_assert(ret[999] == NULL);
+	i_free(ret);
+
+	test_end();
+}
+
 static void test_t_split_key_value(void)
 {
 	const char *key, *value;
@@ -761,6 +781,7 @@ void test_strfuncs(void)
 	test_p_strdup_empty();
 	test_p_strdup_until();
 	test_p_strarray_dup();
+	test_p_strarray_dup_large_inputs();
 	test_t_split_key_value();
 	test_t_strsplit();
 	test_t_strsplit_spaces();


### PR DESCRIPTION
p_strarray_dup() accumulates allocation size in a loop:

    size += sizeof(const char *) + strlen(arr[i]) + 1;

This is done without checking for overflow, so `size` can wrap before
the final allocation. Since the pool allocator only validates the final
size, an overflow here can result in allocating a buffer smaller than
intended.

Fix:
Add a SIZE_MAX guard before the addition to prevent overflow during size
accumulation. This follows the pattern used elsewhere (e.g. MALLOC_ADD)
and keeps failure behavior consistent (i_panic on overflow).

Test:
Add a test with a large input array to exercise the accumulation path
and verify behavior is preserved.