### PR TITLE
Fix PAM response allocation to handle invalid message count

### DIFF
--- a/src/auth/passdb-pam.c
+++ b/src/auth/passdb-pam.c
@@ -113,7 +113,14 @@ pam_userpass_conv(int num_msg, pam_const struct pam_message **msg,
 
 	*resp_r = NULL;
 
-	resp = calloc(num_msg, sizeof(struct pam_response));
+	if (num_msg < 0 ||
+	    (size_t)num_msg > SIZE_MAX / sizeof(struct pam_response)) {
+		e_error(authdb_event(ctx->request),
+			"pam: invalid response count: %d", num_msg);
+		return PAM_CONV_ERR;
+	}
+
+	resp = calloc((size_t)num_msg, sizeof(struct pam_response));
 	if (resp == NULL)
 		i_fatal_status(FATAL_OUTOFMEM, "Out of memory");
 


### PR DESCRIPTION
pam_userpass_conv() allocates the response array using:

    resp = calloc(num_msg, sizeof(struct pam_response));

The multiplication is not explicitly checked for overflow. Although
num_msg originates from PAM, it is external input and should not be
trusted blindly.

Add a SIZE_MAX guard before allocation and fail gracefully if the value
is invalid.

This is a defensive hardening change and does not affect behavior for
valid inputs.
