### PR TITLE
imap-parser-nesting-limit

### DIFF
--- a/src/lib-imap/imap-parser.c
+++ b/src/lib-imap/imap-parser.c
@@ -20,6 +20,10 @@
 	((c) == '\r' || (c) == '\n')
 
 #define LIST_INIT_COUNT 7
+/* Max. nesting depth for lists. This should be enough for all legitimate
+   uses, but small enough to prevent stack exhaustion in recursive
+   imap_arg consumers. */
+#define IMAP_PARSER_MAX_NESTING_DEPTH 100
 
 enum arg_parse_type {
 	ARG_PARSE_NONE = 0,
@@ -48,6 +52,7 @@ struct imap_parser {
         ARRAY_TYPE(imap_arg_list) *cur_list;
 	struct imap_arg *list_arg;
 	unsigned int list_count;
+	unsigned int cur_nesting_depth;
 
 	enum arg_parse_type cur_type;
 	size_t cur_pos; /* parser position in input buffer */
@@ -129,6 +134,7 @@ void imap_parser_reset(struct imap_parser *parser)
 	parser->cur_list = &parser->root_list;
 	parser->list_arg = NULL;
 	parser->list_count = 0;
+	parser->cur_nesting_depth = 0;
 
 	parser->cur_type = ARG_PARSE_NONE;
 	parser->cur_pos = 0;
@@ -191,8 +197,16 @@ static struct imap_arg *imap_arg_create(struct imap_parser *parser)
 	return arg;
 }
 
-static void imap_parser_open_list(struct imap_parser *parser)
+static bool imap_parser_open_list(struct imap_parser *parser)
 {
+	if (parser->cur_nesting_depth >= IMAP_PARSER_MAX_NESTING_DEPTH ||
+	    parser->cur_nesting_depth >= parser->list_count_limit) {
+		parser->error_msg = "List nesting too deep";
+		parser->error = IMAP_PARSE_ERROR_BAD_SYNTAX;
+		return FALSE;
+	}
+	parser->cur_nesting_depth++;
+
 	parser->list_arg = imap_arg_create(parser);
 	parser->list_arg->type = IMAP_ARG_LIST;
 	p_array_init(&parser->list_arg->_data.list, parser->pool,
@@ -200,6 +214,7 @@ static void imap_parser_open_list(struct imap_parser *parser)
 	parser->cur_list = &parser->list_arg->_data.list;
 
 	parser->cur_type = ARG_PARSE_NONE;
+	return TRUE;
 }
 
 static bool imap_parser_close_list(struct imap_parser *parser)
@@ -227,6 +242,8 @@ static bool imap_parser_close_list(struct imap_parser *parser)
 	arg = imap_arg_create(parser);
 	arg->type = IMAP_ARG_EOL;
 
+	i_assert(parser->cur_nesting_depth > 0);
+	parser->cur_nesting_depth--;
 	parser->list_arg = parser->list_arg->parent;
 	if (parser->list_arg == NULL) {
 		parser->cur_list = &parser->root_list;
@@ -673,7 +690,8 @@ static bool imap_parser_read_arg(struct imap_parser *parser)
 			parser->literal8 = FALSE;
 			break;
 		case '(':
-			imap_parser_open_list(parser);
+			if (!imap_parser_open_list(parser))
+				return FALSE;
 			if ((parser->flags & IMAP_PARSE_FLAG_STOP_AT_LIST) != 0) {
 				i_stream_skip(parser->input, 1);
 				return FALSE;

--- a/src/lib-imap/test-imap-parser.c
+++ b/src/lib-imap/test-imap-parser.c
@@ -245,6 +245,45 @@ static void test_imap_parser_read_literal(void)
 	test_end();
 }
 
+static void test_imap_parser_nesting_limit(void)
+{
+	struct istream *input;
+	struct imap_parser *parser;
+	const struct imap_arg *args;
+	char *test_input;
+	unsigned int i, depth = 101;
+
+	test_begin("imap parser nesting limit");
+
+	test_input = t_malloc(depth + 3);
+	for (i = 0; i < depth; i++)
+		test_input[i] = '(';
+	test_input[i++] = ')';
+	test_input[i++] = '\n';
+	test_input[i++] = '\0';
+
+	/* test default ceiling (100) */
+	input = test_istream_create(test_input);
+	parser = imap_parser_create(input, NULL, 1024, NULL);
+	(void)i_stream_read(input);
+	test_assert_idx(imap_parser_read_args(parser, 0, 0, &args) == -1, 0);
+	test_assert_idx(strcmp(imap_parser_get_error(parser, NULL), "List nesting too deep") == 0, 0);
+	imap_parser_unref(&parser);
+	i_stream_destroy(&input);
+
+	/* test custom list_count_limit (2) */
+	const struct imap_parser_params params = { .list_count_limit = 2 };
+	input = test_istream_create("((()))\n");
+	parser = imap_parser_create(input, NULL, 1024, &params);
+	(void)i_stream_read(input);
+	test_assert_idx(imap_parser_read_args(parser, 0, 0, &args) == -1, 1);
+	test_assert_idx(strcmp(imap_parser_get_error(parser, NULL), "List nesting too deep") == 0, 1);
+	imap_parser_unref(&parser);
+	i_stream_destroy(&input);
+
+	test_end();
+}
+
 int main(void)
 {
 	static void (*const test_functions[])(void) = {
@@ -253,6 +292,7 @@ int main(void)
 		test_imap_parser_list_limit,
 		test_imap_parser_read_tag_cmd,
 		test_imap_parser_read_literal,
+		test_imap_parser_nesting_limit,
 		NULL
 	};
 	return test_run(test_functions);


### PR DESCRIPTION
The IMAP parser currently tracks list_count_limit, but nested list depth is only constrained after lists are closed. This means deeply nested input can still build a large recursive imap_arg tree before the limit is enforced.

Several downstream imap_arg consumers traverse these structures recursively, so excessively deep nesting may lead to stack exhaustion.

This change adds proactive nesting-depth enforcement when opening lists by:

* tracking current nesting depth during parsing
* rejecting input once nesting exceeds the configured list_count_limit
* applying a hard safety ceiling of 100 levels to protect recursive consumers even if a higher limit is configured

The hard ceiling is intentionally conservative and aligns with similar nesting limits elsewhere in the codebase.

Tests are included for both:

* the default hard nesting ceiling
* custom list_count_limit enforcement
