### PR TITLE
lib-dict-backend: cdb - Fix use-after-realloc of iterated key pointer

### DIFF
--- a/src/lib-dict-backend/dict-cdb.c
+++ b/src/lib-dict-backend/dict-cdb.c
@@ -248,24 +248,27 @@ static bool cdb_dict_iterate(struct dict_iterate_context *_ctx,
 	if (!match)
 		return FALSE;
 
-	*key_r = key;
+	if ((ctx->flags & DICT_ITERATE_FLAG_NO_VALUE) == 0) {
+		datalen = cdb_datalen(&dict->cdb);
+		data = buffer_append_space_unsafe(ctx->buffer, datalen + 1);
 
-	if ((ctx->flags & DICT_ITERATE_FLAG_NO_VALUE) != 0)
-		return TRUE;
+		if (cdb_read(&dict->cdb, data, datalen, cdb_datapos(&dict->cdb)) < 0) {
+			ctx->error = i_strdup_printf("cdb_read(%s) failed: %m",
+						     dict->path);
+			return FALSE;
+		}
 
-	datalen = cdb_datalen(&dict->cdb);
-	data = buffer_append_space_unsafe(ctx->buffer, datalen + 1);
-
-	if (cdb_read(&dict->cdb, data, datalen, cdb_datapos(&dict->cdb)) < 0) {
-		ctx->error = i_strdup_printf("cdb_read(%s) failed: %m",
-					     dict->path);
-		return FALSE;
+		data[datalen] = '\0';
+		ctx->values[0] = data;
+		*values_r = ctx->values;
 	}
 
-	data[datalen] = '\0';
-	ctx->values[0] = data;
-	*values_r = ctx->values;
-
+	/* cdb_dict_next() placed the key at the start of ctx->buffer. The
+	   buffer_append_space_unsafe() above may have reallocated ctx->buffer
+	   to fit the value, which would invalidate the local `key` pointer
+	   returned by cdb_dict_next(). Re-derive it from the buffer's current
+	   data pointer. */
+	*key_r = ctx->buffer->data;
 	return TRUE;
 }
 


### PR DESCRIPTION
## What

In `src/lib-dict-backend/dict-cdb.c`, `cdb_dict_iterate()` returns a
`*key_r` pointer that can be dangling by the time the function returns.

`cdb_dict_next()` reuses `ctx->buffer` for both the key and the value:

- It calls `buffer_set_used_size(ctx->buffer, 0)`, then
  `buffer_append_space_unsafe(ctx->buffer, key_len + 1)`, and returns a
  pointer to offset 0 of the buffer via `*key_r`
  (`src/lib-dict-backend/dict-cdb.c:204-216`).

`cdb_dict_iterate()` then:

1. Writes that pointer to the caller's `*key_r` slot
   (line 251, before this fix).
2. Appends the value into the same buffer with
   `buffer_append_space_unsafe(ctx->buffer, datalen + 1)` at line 257.

The buffer is created from `default_pool` with an initial size of 256
bytes (`cdb_dict_iterate_init`, line 182). When
`key_len + 1 + value_len + 1` exceeds the current allocation, the
value append goes through `buffer_check_limits()` ->
`p_realloc()` -> `pool_system_realloc()` -> `realloc(3)`
(`src/lib/buffer.c:47`, `src/lib/mempool-system.c:133`), which can move
the backing memory and free the previous allocation. The pointer that
was written into the caller's `*key_r` now references freed memory,
and the next caller dereference is a heap-use-after-free.

## How to reproduce

Reproduced the realloc/UAF pattern as a standalone case under
AddressSanitizer using the same allocation sequence as
`cdb_dict_iterate`: place a key at the start of a 256-byte dynamic
buffer, save the pointer, then append a value large enough to force a
realloc. ASan reports `heap-use-after-free` on the saved key pointer
because `realloc()` moved the buffer and freed the original
allocation. In Dovecot the same trigger is a CDB entry whose
`strlen(key) + strlen(value) + 2` exceeds 256.

## The fix

Move the `*key_r = ...` assignment to after the value append, and
re-derive the key from `ctx->buffer->data`. The key is always at
offset 0 of the buffer (by construction in `cdb_dict_next()`), so
reading the buffer's current data pointer yields the post-realloc
address regardless of whether the value append moved the buffer.
The fix is contained to the callee and does not change any caller
contract.

## Test plan

- [x] Reproduced the realloc-induced UAF pattern under ASan in a
      standalone program.
- [x] Confirmed the same pattern with the key pointer re-derived from
      the buffer base after the append is clean under ASan.
- [x] Patched file syntax-checks cleanly with `-Wall -Wextra` against
      the configured tree (only pre-existing unused-parameter warning
      remains).