### PR TITLE
fts: build-mail - Bound content_type_params copy by parser end

### DIFF
--- a/src/plugins/fts/fts-build-mail.c
+++ b/src/plugins/fts/fts-build-mail.c
@@ -61,7 +61,8 @@ static void fts_build_parse_content_type(struct fts_mail_build_context *ctx,
 		/* ... then store the remainder of the line - which may contain RFC2231
 		   parameters - without parsing it because not all backends need them. In
 		   the backends that need them further parsing can be implemented. */
-		ctx->content_type_params = i_strdup((const char *)parser.data);
+		ctx->content_type_params =
+			i_strndup(parser.data, parser.end - parser.data);
 	} T_END;
 	rfc822_parser_deinit(&parser);
 }


### PR DESCRIPTION
fts_build_parse_content_type() captures the params remainder with
i_strdup(parser.data), but parser.data points into hdr->full_value,
which is a (data, len) buffer, not a C string. message-header-parser
reuses value_buf across calls via buffer_set_used_size(0), so bytes
past full_value_len can be leftover from a previous header value.
Switch to i_strndup with parser.end - parser.data.