### PR TITLE
lib-oauth2: jwt - Avoid use-after-realloc of jwt_node front pointer

### DIFF
--- a/src/lib-oauth2/oauth2-jwt.c
+++ b/src/lib-oauth2/oauth2-jwt.c
@@ -387,6 +387,7 @@ oauth2_jwt_copy_fields(ARRAY_TYPE(oauth2_field) *fields,
 
 			if (!json_node_is_singular(jnode)) {
 				root = array_append_space(&nodes);
+				subroot = array_front(&nodes);
 				root->root = json_tree_node_get_child(tnode);
 				root->array = json_node_is_array(jnode);
 				if (jnode->name == NULL)

--- a/src/lib-oauth2/oauth2-jwt.c
+++ b/src/lib-oauth2/oauth2-jwt.c
@@ -387,6 +387,8 @@ oauth2_jwt_copy_fields(ARRAY_TYPE(oauth2_field) *fields,
 
 			if (!json_node_is_singular(jnode)) {
 				root = array_append_space(&nodes);
+				/* array_append_space() may have reallocated the
+				   buffer, so refresh subroot to the new location. */
 				subroot = array_front(&nodes);
 				root->root = json_tree_node_get_child(tnode);
 				root->array = json_node_is_array(jnode);


### PR DESCRIPTION
oauth2_jwt_copy_fields() captures subroot from array_front(&nodes)
then calls array_append_space(&nodes) inside the inner loop. When the
append cannot extend the buffer in place it relocates it, so subroot
aliases the previous slot and later subroot->prefix / subroot->array
reads operate on the abandoned location. Copy the front node by value
before the append.