### PR TITLE
lib-storage: index-thread - fix array pre-allocation panic from cmd_thread

### DIFF
--- a/src/lib-storage/index/index-thread-finish.c
+++ b/src/lib-storage/index/index-thread-finish.c
@@ -337,7 +337,7 @@ static void mail_thread_root_thread_merge(struct thread_finish_context *ctx,
 		array_push_back(&ctx->roots, &new_root);
 
 		/* make sure all shadow indexes are accessible directly */
-		(void)array_idx_modifiable(&ctx->shadow_nodes,
+		(void)array_idx_get_space(&ctx->shadow_nodes,
 					   new_root.node.idx);
 	}
 }

--- a/src/lib-storage/index/index-thread.c
+++ b/src/lib-storage/index/index-thread.c
@@ -185,7 +185,7 @@ static void mail_thread_strmap_remap(const uint32_t *idx_map,
 	i_array_init(&new_nodes, new_count + invalid_count + 32);
 
 	/* optimization: allocate all nodes initially */
-	(void)array_idx_modifiable(&new_nodes, new_count-1);
+	(void)array_idx_get_space(&new_nodes, new_count-1);
 
 	/* renumber existing valid nodes. all existing records in old_nodes
 	   should also exist in idx_map since we've removed expunged messages


### PR DESCRIPTION
## What

`mail_thread_strmap_remap()` panics from `cmd_thread` with:

```
Panic: file array.c: line 10 (array_idx_modifiable_i):
  assertion failed: (idx < array->buffer->used / array->element_size)
```

`src/lib-storage/index/index-thread.c:185-200`:

```c
i_array_init(&new_nodes, new_count + invalid_count + 32);

/* optimization: allocate all nodes initially */
(void)array_idx_modifiable(&new_nodes, new_count-1);

for (i = 0; i < old_count; i++) {
    if (idx_map[i] != 0) {
        node = array_idx_modifiable(&new_nodes, idx_map[i]);
        ...
```

The pre-allocation comment is wrong on two counts:

1. `array_idx_modifiable_i()` is `ATTR_PURE` (`src/lib/array.h:315`).
   The `(void)`-discarded call at line 188 is elided under `-O2`. It
   has been dead code in optimized builds.
2. Even if it ran, `array_idx_modifiable_i()` asserts on
   `idx < buffer->used / element_size` and does not grow `used`. After
   `i_array_init()`, `used == 0`.

So `new_nodes` stays empty, and the loop body at line 200 (return
consumed by `node = ...`, not elided) asserts the first time
`idx_map[i] != 0`. The captured stack confirms the fault frame is at
`index-thread.c:200`, not `:188`. At panic time
`new_nodes.arr.buffer->used == 0` while `new_count == 8`:

```
#7  array_idx_modifiable_i (array=..., idx=<optimized out>) at array.c:10
#8  mail_thread_strmap_remap (idx_map=..., old_count=..., new_count=8,
                              context=...) at index-thread.c:200
#9  mail_index_strmap_view_renumber (view=...) at mail-index-strmap.c:867
#10 mail_index_strmap_write (view=...) at mail-index-strmap.c:1192
#11 mail_index_strmap_view_sync_commit (...) at mail-index-strmap.c:1239
#12 mail_thread_index_map_build (...) at index-thread.c:359
#13 mail_thread_init (...) at index-thread.c:573
#14 imap_thread (...) at cmd-thread.c:90
#15 cmd_thread (...) at cmd-thread.c:282
```

The same shape exists at `src/lib-storage/index/index-thread-finish.c:340`
in `mail_thread_root_thread_merge()` (`ctx->shadow_nodes` is grown via
the same `(void)array_idx_modifiable(...)` pattern after
`i_array_init()`).

## How to reproduce

Standalone libdovecot program, no storage, no plugins, panics at both
`-O0` and `-O2`:

```c
#include "lib.h"
#include "array.h"
#include <stdio.h>

int main(void)
{
    lib_init();

    ARRAY(int) arr;
    i_array_init(&arr, 16);

    int *node = array_idx_modifiable(&arr, 1);
    printf("unreachable: %p\n", (void *)node);
    return 0;
}
```

Sinking the return through `printf()` defeats the `ATTR_PURE` elision
that hides the buggy line-188 form, and mirrors line 200 (where the
production panic actually fires). Exits 134 with the same assertion
string as the production frame `#7`. Verified against `main` HEAD
(`e71c7207`); no drift in either affected file between the `2.4.3`
tag and `main`, so the same hunk applies to both.

## The fix

Replace both `(void)array_idx_modifiable(...)` pre-allocation calls
with `array_idx_get_space()`, which is declared without `ATTR_PURE`
and grows the buffer through `buffer_get_space_unsafe()`. Same idiom
is already used in the same file at `index-thread-finish.c:524-526`
on the same struct (`ctx->shadow_nodes`).

`array_idx_get_space()` is a strict generalization of
`array_idx_modifiable()` for the "pointer to element at idx" use: on
already-grown buffers both return the same pointer; on under-grown
buffers `array_idx_modifiable()` asserts while `array_idx_get_space()`
grows. The substitution does not change any caller contract.
