### PR TITLE
lib-mail: message-parser - Fix out-of-bounds read on empty preamble

### DIFF
--- a/src/lib-mail/message-parser-from-parts.c
+++ b/src/lib-mail/message-parser-from-parts.c
@@ -121,15 +121,26 @@ static int preparsed_parse_prologue_more(struct message_parser_ctx *ctx,
 			if (*cur == '\n') break;
 		}
 
-		if (cur[0] != '\n' || cur[1] != '-' || cur[2] != '-') {
-			ctx->broken_reason = "Prologue boundary beginning not at expected position";
-			return -1;
+		if (cur < block_r->data) {
+			/* boundary is at the very start of the prologue, i.e.
+			   there is no preamble before it (no preceding newline
+			   to find). Don't read before block_r->data. */
+			if (block_r->data[0] != '-' || block_r->data[1] != '-') {
+				ctx->broken_reason = "Prologue boundary beginning not at expected position";
+				return -1;
+			}
+			block_r->size = 0;
+		} else {
+			if (cur[0] != '\n' || cur[1] != '-' || cur[2] != '-') {
+				ctx->broken_reason = "Prologue boundary beginning not at expected position";
+				return -1;
+			}
+
+			if (cur != block_r->data && cur[-1] == '\r') cur--;
+
+			/* clip boundary */
+			block_r->size = cur - block_r->data;
 		}
-
-		if (cur != block_r->data && cur[-1] == '\r') cur--;
-
-		/* clip boundary */
-		block_r->size = cur - block_r->data;
 
 		ctx->parse_next_block = preparsed_parse_prologue_finish;
 		ctx->skip = block_r->size;

--- a/src/lib-mail/test-message-parser.c
+++ b/src/lib-mail/test-message-parser.c
@@ -1521,6 +1521,50 @@ static void test_message_parser_too_many_header_bytes_100(void)
 	test_end();
 }
 
+static void test_message_parser_preparsed_empty_preamble(void)
+{
+static const char input_msg[] =
+"Content-Type: multipart/mixed; boundary=\"b\"\r\n"
+"\r\n"
+"--b\r\n"
+"Content-Type: text/plain\r\n"
+"\r\n"
+"hello\r\n"
+"--b--\r\n";
+	const struct message_parser_settings preparsed_set = {
+		.flags = MESSAGE_PARSER_FLAG_INCLUDE_MULTIPART_BLOCKS,
+	};
+	struct message_parser_ctx *parser;
+	struct istream *input;
+	struct message_part *parts, *parts2;
+	struct message_block block;
+	const char *error;
+	pool_t pool;
+
+	test_begin("message parser preparsed empty preamble");
+	pool = pool_alloconly_create("message parser", 10240);
+	input = test_istream_create(input_msg);
+	test_istream_set_allow_eof(input, TRUE);
+
+	test_assert(message_parse_stream(pool, input, &set_empty, FALSE, &parts) < 0);
+
+	/* Re-parse from the cached parts, requesting multipart blocks so the
+	   prologue is returned. The prologue region here is exactly the
+	   boundary line ("--b\r\n") with no preamble before it. Before the fix
+	   the backward newline scan walked past block start and clipped the
+	   block to a (size_t)-underflowed length. */
+	i_stream_seek(input, 0);
+	parser = message_parser_init_from_parts(parts, input, &preparsed_set);
+	while (message_parser_parse_next_block(parser, &block) > 0)
+		test_assert(block.size <= sizeof(input_msg));
+	test_assert(message_parser_deinit_from_parts(&parser, &parts2, &error) == 0);
+	test_assert(message_part_is_equal(parts, parts2));
+
+	i_stream_unref(&input);
+	pool_unref(&pool);
+	test_end();
+}
+
 int main(void)
 {
 	static void (*const test_functions[])(void) = {
@@ -1546,6 +1590,7 @@ int main(void)
 		test_message_parser_mime_version_missing,
 		test_message_parser_too_many_header_bytes_default,
 		test_message_parser_too_many_header_bytes_100,
+		test_message_parser_preparsed_empty_preamble,
 		NULL
 	};
 	return test_run(test_functions);


### PR DESCRIPTION
Re-parsing a multipart message from cached parts with
`MESSAGE_PARSER_FLAG_INCLUDE_MULTIPART_BLOCKS`, on a message whose MIME
part has an empty preamble (the boundary is the first thing in the body):

    block: hdr=(nil) size=18446744073709551614
    Panic: nearest_power(18446744073709551615): calculation would overflow

`preparsed_parse_prologue_more()` scans backwards from the boundary's
trailing CRLF for the newline that precedes `--boundary`. With no preamble
the boundary sits at the very start of the prologue block, so the scan runs
off the front and exits with `cur == block_r->data - 1`. `data[-1]` happens
to be the `\n` ending the multipart part header, so the `--` check passes on
`data[0]`/`data[1]` and `block_r->size = cur - block_r->data` underflows to a
near-`SIZE_MAX` value. The prologue block is then handed to the consumer with
that size, which over-reads (the panic above is a consumer appending it).

Reachable via `message_parser_init_from_parts()` when a caller re-parses a
message against its cached `message_part` tree and asks for multipart blocks.

Handle the no-preamble case explicitly: when the backward scan finds no
newline, confirm the block starts with `--` and return an empty prologue.
Regression test added to test-message-parser.c.
