### PR TITLE
lib: uri_parse_ip_literal() - Fix one-byte out-of-bounds read

### DIFF
--- a/src/lib/test-uri.c
+++ b/src/lib/test-uri.c
@@ -74,6 +74,26 @@ static void test_uri_invalid(void)
 	test_end();
 }
 
+static void test_uri_ip_literal_overread(void)
+{
+	/* An IP-literal host "[" with no closing "]". Use an exact-size,
+	   non-NUL-terminated buffer via the size-based API so the scan for
+	   "]" can't hide behind a terminator - a read past the end is caught
+	   under valgrind/ASAN. */
+	static const char data[] = "imap://[";
+	size_t size = strlen(data);
+	unsigned char *buf = i_malloc(size);
+	const char *error = NULL;
+	int ret;
+
+	test_begin("uri ip-literal overread");
+	memcpy(buf, data, size);
+	ret = uri_check_data(buf, size, 0, &error);
+	test_out_quiet("unterminated IP-literal rejected", ret < 0);
+	i_free(buf);
+	test_end();
+}
+
 /* RFC uri tests */
 const char *rfc_uri_tests[] = {
 	/* from RFC 1738 */
@@ -858,6 +878,7 @@ void test_uri(void)
 {
 	test_uri_valid();
 	test_uri_invalid();
+	test_uri_ip_literal_overread();
 	test_uri_rfc();
 	test_uri_escape();
 	test_uri_aaa();

--- a/src/lib/uri-util.c
+++ b/src/lib/uri-util.c
@@ -621,7 +621,7 @@ uri_parse_ip_literal(struct uri_parser *parser, string_t *literal,
 	/* "[" already verified */
 
 	/* Scan for end of address */
-	if ((p = memchr(parser->cur+1, ']', parser->end - parser->cur)) == NULL) {
+	if ((p = memchr(parser->cur+1, ']', parser->end - parser->cur - 1)) == NULL) {
 		parser->error = "Expecting ']' at end of IP-literal";
 		return -1;
 	}


### PR DESCRIPTION
uri_parse_ip_literal() scans for the closing ']' with memchr(parser->cur+1, ']', parser->end - parser->cur), but the readable span starting at cur+1 is only end - cur - 1 bytes, so the length is one too large and the scan reads parser->end itself when no ']' is present. It is reachable from uri_check_data()/uri_parser_init_data() with any authority host that starts with '[' and has no ']'; C-string callers happen to land on the NUL terminator, but a non-NUL-terminated (data, size) buffer makes it a real heap over-read. The added test feeds an exact-size buffer so it trips under valgrind/ASAN, and subtracting the extra byte from the memchr length resolves it.