### PR TITLE
login-common: client - Fix leak of proxy_last_host

### DIFF
--- a/src/login-common/client-common-auth.c
+++ b/src/login-common/client-common-auth.c
@@ -567,9 +567,11 @@ void client_common_proxy_failed(struct client *client,
 
 	client->proxy_last_failure = type;
 	client->proxy_failed = TRUE;
-	if (client->login_proxy != NULL)
+	if (client->login_proxy != NULL) {
+		i_free(client->proxy_last_host);
 		client->proxy_last_host = i_strdup(login_proxy_get_hostport(
 			client->login_proxy));
+	}
 	client_proxy_failed(client);
 }
 

--- a/src/login-common/client-common.c
+++ b/src/login-common/client-common.c
@@ -648,6 +648,7 @@ bool client_unref(struct client **_client)
 	i_free(client->virtual_auth_user);
 	i_free(client->auth_mech_name);
 	i_free(client->last_proxy_auth_failure_reason);
+	i_free(client->proxy_last_host);
 	i_free(client->master_data_prefix);
 	pool_unref(&client->pool);
 

--- a/src/login-common/client-common.h
+++ b/src/login-common/client-common.h
@@ -269,7 +269,7 @@ struct client {
 	const char **alt_usernames;
 
 	/* Last host we tried to connect to */
-	const char *proxy_last_host;
+	char *proxy_last_host;
 
 	bool create_finished:1;
 	bool disconnected:1;


### PR DESCRIPTION
client->proxy_last_host is strdup(3)ed in client_common_proxy_failed() (client-common-auth.c:571) on every login proxy failure, and nothing in the tree frees it. It is the only i_strdup()ed struct client field with no matching free: client_proxy_failed() releases proxy_password, proxy_user and proxy_master_user on that same failure path, and client_unref() releases the other owned strings, but both skip this one. It is also the only one of them declared const char * rather than char *, which is likely why the i_free() never got added.

client_proxy_failed() ends in client_auth_failed(), so the client stays connected and can retry AUTH. Each further proxy failure then overwrites the pointer and leaks the previous hostport string, and the last value leaks when the client is freed. With login_process_per_connection=no a login process serves many connections, so this accumulates over the process lifetime rather than being reclaimed at exit.

The value is read at disconnect for the "proxy dest ... to <host>" log line, so the free goes before the strdup rather than into client_proxy_failed().

One caveat on evidence: LeakSanitizer is unavailable on my machine, so this comes from the allocation and free sites rather than a leak-checker run (grep -rn proxy_last_host src/ returns only the declaration, the strdup, and the read in client-common.c:1563). Glad to add a regression test if you have a preferred way to drive the proxy failure path.