### PR TITLE
doveadm: client-connection-tcp - Don't read past args in flag loop

### DIFF
--- a/src/doveadm/client-connection-tcp.c
+++ b/src/doveadm/client-connection-tcp.c
@@ -290,6 +290,11 @@ static bool client_handle_command_ctx(struct client_connection_tcp *conn,
 			doveadm_verbose = TRUE;
 			break;
 		case DOVEADM_PROTOCOL_CMD_FLAG_EXTRA_FIELDS:
+			if (argc == 0) {
+				e_error(cctx->event, "doveadm client: "
+					"Missing extra fields argument");
+				return FALSE;
+			}
 			cctx->extra_fields = t_strsplit_tabescaped(args[0]);
 			args++; argc--;
 			break;
@@ -298,6 +303,10 @@ static bool client_handle_command_ctx(struct client_connection_tcp *conn,
 				"doveadm client: Unknown flag: %c", *flags);
 			return FALSE;
 		}
+	}
+	if (argc < 2) {
+		e_error(cctx->event, "doveadm client: No command given");
+		return FALSE;
 	}
 	cctx->username = args[0]; args++; argc--;
 	cmd_name = args[0];


### PR DESCRIPTION
client_handle_command_ctx() checks argc>=3 once, before the flag loop, but each 'x' (extra-fields) flag then consumes an args slot with no further check, and the username and command name take two more after it. A doveadm command line whose flag field holds more flag-consumers than there are following arguments makes args walk past the NULL terminator of the t_strsplit_tabescaped() array: with flags "xx" on a three-field line, cmd_name = args[0] reads one entry past the array and argc underflows to UINT_MAX before it reaches doveadm_cmd_handle(). Re-check argc before taking the extra-fields argument and before reading the username and command name.