### PR TITLE
lib-index: mail-index-strmap - Fix OOB read from truncated record size

### DIFF
--- a/src/lib-index/mail-index-strmap.c
+++ b/src/lib-index/mail-index-strmap.c
@@ -63,7 +63,7 @@ struct mail_index_strmap_read_context {
 	const unsigned char *data, *end, *str_idx_base;
 	struct mail_index_strmap_rec rec;
 	uint32_t next_ref_index;
-	unsigned int rec_size;
+	size_t rec_size;
 
 	bool too_large_uids:1;
 };


### PR DESCRIPTION
**Truncated record size in mail_index_strmap_read_rec_first over-reads the block**

A crafted or corrupted `dovecot.index.thread` strmap record can pick a packed count where the record byte size `count * (sizeof(str_idx) + sizeof(crc32))` overflows the 32-bit `rec_size` field: with n=0x20000001 the size 0x100000008 truncates to 8, so `i_stream_read_bytes(input, ..., rec_size)` accepts a tiny block while the code still walks `str_idx_base = data + count*sizeof(uint32_t)` forward by ~2 GiB and reads `count` records past it. Widening `rec_size` to `size_t` keeps the real byte count, so an oversized record fails the stream read and is rejected as corruption, which is how the sibling `doveadm-dump-thread.c` path already treats the same quantity.