### PR TITLE
lib-storage: thread - Fix panic when strmap remaps invalid Message-ID nodes

### DIFF
--- a/src/lib-storage/index/index-thread.c
+++ b/src/lib-storage/index/index-thread.c
@@ -212,7 +212,7 @@ static void mail_thread_strmap_remap(const uint32_t *idx_map,
 	new_first_invalid = new_count + 1 +
 		THREAD_INVALID_MSGID_STR_IDX_SKIP_COUNT;
 	for (i = 0; i < invalid_count; i++) {
-		node = array_idx_modifiable(&new_nodes, new_first_invalid + i);
+		node = array_idx_get_space(&new_nodes, new_first_invalid + i);
 		*node = old_nodes[cache->first_invalid_msgid_str_idx + i];
 		if (node->parent_idx != 0) {
 			node->parent_idx = idx_map[node->parent_idx];


### PR DESCRIPTION
**Panic**

```
Panic: file array.c: line 10 (array_idx_modifiable_i): assertion failed: (idx < array->buffer->used / array->element_size)
```

Backtrace (from a captured core of the reproduction below):

```
#9  array_idx_modifiable_i (array=..., idx=344) at array.c:10
#10 mail_thread_strmap_remap (idx_map=..., old_count=6, new_count=2, context=...) at index-thread.c:215
#11 mail_index_strmap_view_renumber (view=...) at mail-index-strmap.c:867
#12 mail_index_strmap_write (view=...) at mail-index-strmap.c:1192
#13 mail_index_strmap_view_sync_commit (...) at mail-index-strmap.c:1239
```

This is the same function and the same crash as 83f2593552b30d6705ec49ae72cfa047ad7320c5, one loop lower. That commit converted the valid-node pre-allocation at index-thread.c:188 to array_idx_get_space(). The invalid-node copy loop at line 215 still calls array_idx_modifiable() on index `new_first_invalid + i`, which is `new_count + 1 + THREAD_INVALID_MSGID_STR_IDX_SKIP_COUNT + i`. new_nodes is only grown to `new_count` elements at line 188, so the first invalid node (i=0) is `new_count + 342` past the end (SKIP_COUNT = 4096 / sizeof(struct mail_thread_node) = 341). Before 1d4e5de8414ed93d1c810b30a91ad83d6d954861, array_idx_modifiable() grew the array, so this was in bounds; since that commit it only asserts.

**Reachability**

Stock IMAP THREAD. `invalid_count > 0` whenever the cached thread contains a duplicate Message-ID (thread_msg_add() in index-thread-links.c increments next_invalid_msgid_str_idx for the second message with the same Message-ID). The remap callback fires from mail_index_strmap_view_renumber() when STRIDX_MUST_RENUMBER triggers on strmap write, i.e. after enough messages that were assigned string indexes have been expunged that the highest index exceeds twice the live unique count. Any mailbox that (a) is threaded, (b) contains a duplicate Message-ID (common: list mail, resent mail, a Sent+Inbox copy), and (c) sees continued add/expunge churn against a shared on-disk strmap will hit this.

**Culprit commit**

Behavior change: 1d4e5de8414ed93d1c810b30a91ad83d6d954861 ("lib: array_idx_modifiable changed not to allocate space."). The line itself dates to 34c80f444aeee0fa752a06c7f8ed38226c0f5edb (2008) and relied on the old grow-on-access semantics, as did index-thread.c:188 before 83f2593552b30d6705ec49ae72cfa047ad7320c5. array_idx_get_space() is exactly the pre-2017 behavior.

83f2593's reproduction contained no duplicate Message-IDs, so invalid_count was 0 and this loop never ran. Audited the remaining array_idx_modifiable() call sites: one other pre-2017 caller (mail_index_ext_rec_updates_resize in mail-index-transaction-update.c) used grow-on-access to reach its array_is_created() early return and can now assert, but only when a transaction updates one extension's records and then grows a higher-numbered extension's record_size, and we found no in-tree caller that does that. Every other site is provably in-bounds.

**Reproduction**

In-process libdovecot-storage test program, sdbox, two mailbox handles on one INBOX modeling two IMAP connections. Handle A caches a THREAD result containing one duplicate Message-ID, so its cache keeps invalid_count=1. Handle B appends one unique message and expunges it each round, growing the shared on-disk strmap's highest index past the live unique count. When A re-threads and its strmap view renumbers, mail_thread_strmap_remap() runs with new_count=2 and invalid_count=1 and panics at line 215 with idx=344.

- Unpatched HEAD: panic within a few thousand rounds, backtrace above.
- With the one-line change: 4000 rounds clean.

Same test, same tree; the only difference between the two builds is the one line.

<details>
<summary>Test program (drop in as src/lib-storage/test-mail-storage.c, then make -C src/lib-storage test-mail-storage)</summary>

```c
/* Reproducer for the mail_thread_strmap_remap() panic at index-thread.c:215.
 *
 * Drop this in as src/lib-storage/test-mail-storage.c (replacing the file),
 * then: make -C src/lib-storage test-mail-storage
 *       ./libtool --mode=execute src/lib-storage/test-mail-storage
 *
 * Unpatched HEAD: panics within a few thousand rounds:
 *   Panic: file array.c: line 10 (array_idx_modifiable_i):
 *     assertion failed: (idx < array->buffer->used / array->element_size)
 *   #10 mail_thread_strmap_remap (... new_count=2 ...) at index-thread.c:215
 * With line 215 changed to array_idx_get_space(): 4000 rounds clean.
 *
 * Two mailbox handles (A, B) on the same INBOX model two IMAP connections.
 * A caches a THREAD result containing one duplicate (invalid) Message-ID, so
 * A's cache keeps invalid_count==1 with search_result set. B churns unique
 * messages (append + expunge), growing the shared on-disk strmap's highest
 * str_idx past the live unique count. When A re-threads and its strmap view
 * renumbers, mail_thread_strmap_remap() runs with new_count>0 and
 * invalid_count==1 and dereferences an index (new_count+1+SKIP_COUNT) the
 * new_nodes array was never grown to.
 */

#include "lib.h"
#include "array.h"
#include "istream.h"
#include "str.h"
#include "master-service.h"
#include "mail-storage-private.h"
#include "mail-namespace.h"
#include "mail-search-build.h"
#include "mail-thread.h"
#include "test-common.h"
#include "test-dir.h"
#include "test-mail-storage-common.h"

static void save_mail(struct mailbox *box, const char *msgid)
{
	struct mailbox_transaction_context *trans;
	struct mail_save_context *save_ctx;
	struct istream *input;
	string_t *m = t_str_new(256);
	static unsigned int ctr = 0;
	int ret;

	str_printfa(m, "Message-ID: <%s>\r\nSubject: s\r\n"
		    "From: s@ex.com\r\nTo: r@ex.com\r\n"
		    "Date: Wed, 15 Aug 2026 00:00:00 +0000\r\n\r\nbody %u\r\n",
		    msgid, ctr++);
	input = i_stream_create_from_data(str_data(m), str_len(m));
	trans = mailbox_transaction_begin(box,
			MAILBOX_TRANSACTION_FLAG_EXTERNAL, __func__);
	save_ctx = mailbox_save_alloc(trans);
	if (mailbox_save_begin(&save_ctx, input) < 0)
		i_fatal("save_begin: %s", mailbox_get_last_internal_error(box, NULL));
	while ((ret = i_stream_read(input)) > 0)
		if (mailbox_save_continue(save_ctx) < 0)
			i_fatal("save_continue failed");
	i_assert(ret == -1);
	if (mailbox_save_finish(&save_ctx) < 0)
		i_fatal("save_finish: %s", mailbox_get_last_internal_error(box, NULL));
	if (mailbox_transaction_commit(&trans) < 0)
		i_fatal("commit: %s", mailbox_get_last_internal_error(box, NULL));
	if (mailbox_sync(box, 0) < 0)
		i_fatal("sync: %s", mailbox_get_last_internal_error(box, NULL));
}

static void run_thread(struct mailbox *box)
{
	struct mail_thread_context *ctx;
	struct mail_thread_iterate_context *iter, *child;
	const struct mail_thread_child_node *node;

	if (mailbox_sync(box, 0) < 0)
		i_fatal("sync: %s", mailbox_get_last_internal_error(box, NULL));
	if (mail_thread_init(box, NULL, &ctx) < 0)
		i_fatal("mail_thread_init: %s",
			mailbox_get_last_internal_error(box, NULL));
	iter = mail_thread_iterate_init(ctx, MAIL_THREAD_REFERENCES, FALSE);
	while ((node = mail_thread_iterate_next(iter, &child)) != NULL) {
		if (child != NULL)
			(void)mail_thread_iterate_deinit(&child);
	}
	(void)mail_thread_iterate_deinit(&iter);
	mail_thread_deinit(&ctx);
}

static void expunge_range(struct mailbox *box, uint32_t seq1, uint32_t seq2)
{
	struct mailbox_transaction_context *trans;
	struct mail *mail;
	uint32_t seq;

	trans = mailbox_transaction_begin(box,
			MAILBOX_TRANSACTION_FLAG_EXTERNAL, __func__);
	mail = mail_alloc(trans, 0, NULL);
	for (seq = seq1; seq <= seq2; seq++) {
		mail_set_seq(mail, seq);
		mail_expunge(mail);
	}
	mail_free(&mail);
	if (mailbox_transaction_commit(&trans) < 0)
		i_fatal("expunge commit: %s",
			mailbox_get_last_internal_error(box, NULL));
	if (mailbox_sync(box, 0) < 0)
		i_fatal("sync: %s", mailbox_get_last_internal_error(box, NULL));
}

static unsigned int msg_count(struct mailbox *box)
{
	struct mailbox_status status;
	mailbox_get_open_status(box, STATUS_MESSAGES, &status);
	return status.messages;
}

static void test_thread_remap_invalid(void)
{
	struct test_mail_storage_ctx *ctx;
	struct mail_namespace *ns;
	struct mailbox *box_a, *box_b;
	unsigned int round;

	test_begin("thread strmap remap with invalid msgid");

	ctx = test_mail_storage_init();
	struct test_mail_storage_settings set = {
		.driver = "sdbox",
		.hierarchy_sep = ".",
	};
	test_mail_storage_init_user(ctx, &set);
	ns = mail_namespace_find_inbox(ctx->user->namespaces);

	box_a = mailbox_alloc(ns->list, "INBOX", 0);
	if (mailbox_open(box_a) < 0)
		i_fatal("open A: %s", mailbox_get_last_internal_error(box_a, NULL));
	box_b = mailbox_alloc(ns->list, "INBOX", 0);
	if (mailbox_open(box_b) < 0)
		i_fatal("open B: %s", mailbox_get_last_internal_error(box_b, NULL));

	/* Two permanent duplicate-msgid messages -> persistent invalid node. */
	save_mail(box_b, "dup@ex.com");
	save_mail(box_b, "dup@ex.com");

	/* A caches the THREAD result including the invalid node. */
	run_thread(box_a);

	for (round = 0; round < 4000; round++) {
		unsigned int n;
		save_mail(box_b, t_strdup_printf("u-%u@ex.com", round));
		run_thread(box_b);
		n = msg_count(box_b);
		if (n > 2)
			expunge_range(box_b, 3, n);
		run_thread(box_b);
		run_thread(box_a);
	}

	printf("NO_CRASH: completed %u rounds\n", round);
	mailbox_close(box_a);
	mailbox_free(&box_a);
	mailbox_close(box_b);
	mailbox_free(&box_b);
	test_mail_storage_deinit_user(ctx);
	test_mail_storage_deinit(&ctx);
	test_end();
}

int main(int argc, char **argv)
{
	int ret;
	void (*const tests[])(void) = { test_thread_remap_invalid, NULL };

	master_service = master_service_init("test-mail-storage",
					     MASTER_SERVICE_FLAG_STANDALONE |
					     MASTER_SERVICE_FLAG_DONT_SEND_STATS |
					     MASTER_SERVICE_FLAG_CONFIG_BUILTIN |
					     MASTER_SERVICE_FLAG_NO_SSL_INIT |
					     MASTER_SERVICE_FLAG_NO_INIT_DATASTACK_FRAME,
					     &argc, &argv, "");
	test_dir_init("test-mail-storage");
	ret = test_run(tests);
	master_service_deinit(&master_service);
	return ret;
}
```

</details>

