### PR TITLE
auth: db-oauth2 - require all configured scopes in token

### DIFF
--- a/src/auth/db-oauth2.c
+++ b/src/auth/db-oauth2.c
@@ -592,9 +592,12 @@ db_oauth2_token_in_scope(struct db_oauth2_request *req,
 			const char *const *entries = has_scope ?
 				t_strsplit_spaces(value, " ") :
 				t_strsplit_tabescaped(value);
+			found = TRUE;
 			array_foreach_elem(&req->db->set->scope, wanted_scope) {
-				if ((found = str_array_find(entries, wanted_scope)))
+				if (!str_array_find(entries, wanted_scope)) {
+					found = FALSE;
 					break;
+				}
 			}
 		}
 		if (!found) {


### PR DESCRIPTION
db_oauth2_token_in_scope() treats oauth2_scope as any-of: the loop breaks as soon as the token carries one of the configured scopes, so a token missing the rest still authenticates in introspection and tokeninfo modes. The JWT local-validation path (check_scope in lib-oauth2/oauth2-jwt.c) already requires every configured scope, and test-oauth2-jwt covers that behavior. Fail when any configured scope is absent so both validation paths enforce the setting the same way.