### PR TITLE
lib: strnum - Reject empty string in str_to_float() and str_to_double()

### DIFF
--- a/src/lib/strnum.c
+++ b/src/lib/strnum.c
@@ -460,7 +460,9 @@ int str_to_float(const char *str, float *num_r)
 {
 	char *endp;
 	float num = strtof(str, &endp);
-	if (*endp != '\0')
+	/* strtof() performs no conversion for an empty string and leaves endp
+	   pointing at str, so the *endp check alone would accept "" as 0. */
+	if (endp == str || *endp != '\0')
 		return -1;
 
 	*num_r = num;
@@ -471,7 +473,9 @@ int str_to_double(const char *str, double *num_r)
 {
 	char *endp;
 	double num = strtod(str, &endp);
-	if (*endp != '\0')
+	/* strtod() performs no conversion for an empty string and leaves endp
+	   pointing at str, so the *endp check alone would accept "" as 0. */
+	if (endp == str || *endp != '\0')
 		return -1;
 
 	*num_r = num;

--- a/src/lib/test-strnum.c
+++ b/src/lib/test-strnum.c
@@ -375,6 +375,8 @@ static void test_str_to_float(void)
 		INVALID(0.1x),
 		INVALID(0.1.2),
 		INVALID(bad),
+		/* strtof()/strtod() consume nothing here, so endp stays at str */
+		{ "", -1, 0 },
 	};
 	test_begin("str_to_int");
 	for (i = 0; i < N_ELEMENTS(tests); ++i) {

--- a/src/lib/test-strnum.c
+++ b/src/lib/test-strnum.c
@@ -378,7 +378,7 @@ static void test_str_to_float(void)
 		/* strtof()/strtod() consume nothing here, so endp stays at str */
 		{ "", -1, 0 },
 	};
-	test_begin("str_to_int");
+	test_begin("str_to_float");
 	for (i = 0; i < N_ELEMENTS(tests); ++i) {
 		float val = 1234.0;
 		double val2 = 1234.0;


### PR DESCRIPTION
`str_to_float("")` and `str_to_double("")` return 0 and store 0 in `*num_r` instead of failing.

`strtof()`/`strtod()` perform no conversion for an empty string. They return 0 and leave `endp` pointing at `str`. The check in both functions only looks at `*endp`, and `*endp` is the terminating NUL, so the empty string passes as a valid 0. Every other `str_to_*()` in strnum.c rejects input that isn't a number, so this one is the odd one out.

The fix is to also require that `endp` moved past `str`.

Where it shows up in tree: dict-sql's `DICT_SQL_TYPE_DOUBLE` case accepts an empty field value and stores 0.0 for it, while `DICT_SQL_TYPE_UINT` sitting right above it rejects the same value because `str_to_int64()` validates it. Two adjacent cases in one switch disagreeing about empty input.

How I checked it: I couldn't build Dovecot on this machine (Windows, no autotools), so I pulled `str_to_float()`/`str_to_double()` out verbatim and compiled them standalone with gcc, before and after the change. Running every string of length 0 to 3 over the characters `0 1 . - + e x space n i` — 1111 inputs, covering digits, signs, exponents, hex and inf/nan prefixes and whitespace — the two versions differ on exactly one input, the empty string. Nothing else moves, which matches the reasoning above: anything `strto[fd]()` refuses leaves a non-NUL character behind for the `*endp` check to catch.

I also ran the `tests[]` table from `test_str_to_float()` against both versions. The seven existing cases pass either way; the new `""` case fails before the change and passes after.

The second commit is a one-liner for `test_str_to_float()` calling `test_begin("str_to_int")`, which would have reported the new failure under the wrong test name. Happy to drop it if you'd rather keep it separate.

Introduced in e8274ded69.