### PR TITLE
lib-sasl: Avoid null pointer in empty response check

### DIFF
--- a/src/lib-sasl/sasl-server-request.c
+++ b/src/lib-sasl/sasl-server-request.c
@@ -164,7 +164,7 @@ sasl_server_request_fail_on_nuls(struct sasl_server_request *req,
 
 	if ((mech->def->flags & SASL_MECH_SEC_ALLOW_NULS) != 0)
 		return FALSE;
-	if (memchr(data, '\0', data_size) != NULL) {
+	if (data_size > 0 && memchr(data, '\0', data_size) != NULL) {
 		e_debug(req->event, "Unexpected NUL in auth data");
 		sasl_server_request_failure(req->mech);
 		return TRUE;


### PR DESCRIPTION
`sasl_server_request_initial()` permits a null data pointer when the response size is zero. This is the normal no-initial-response case used by mechanisms such as LOGIN and CRAM-MD5. The NUL check still passed that pointer to `memchr()`, which is undefined by the C library contract even with a zero length and is reported by UBSan.

Skip the scan when the response is empty. Non-empty response handling is unchanged.

Tests:

- Current base: `b2b2d74e0900e3e3d0ba0392fac9c4cce989aab1`
- `test-sasl-authentication`: 533 tests passed with Clang UBSan, with the unrelated function-type sanitizer disabled
- `test-sasl-authentication`: 533 tests passed with GCC
- POP3 loopback `AUTH LOGIN`: normal challenge, no UBSan diagnostic
- POP3 loopback mutation campaign: 5,000 sessions, no sanitizer diagnostic