### PR TITLE
lib-imap: imap-utf7 - Reject invalid octet in imap_utf7_to_utf8()

### DIFF
--- a/src/lib-imap/imap-utf7.c
+++ b/src/lib-imap/imap-utf7.c
@@ -313,6 +313,13 @@ imap_utf7_to_utf8_int(const char *src, const char *escape_chars, string_t *dest)
 	while (*p != '\0') {
 		if (strchr(escape_chars, *p) != NULL ||
 		    *p < 0x20 || *p >= 0x7f) {
+			if (escape_chars[0] == '\0') {
+				/* non-escaped API: an 8-bit or control octet
+				   outside a shift sequence is invalid mUTF-7.
+				   Reject it like the mbase64 failure path below
+				   instead of emitting a NUL escape char. */
+				return -1;
+			}
 			str_printfa(dest, "%c%02x", escape_chars[0],
 				    (unsigned char)*p);
 			p++;

--- a/src/lib-imap/test-imap-utf7.c
+++ b/src/lib-imap/test-imap-utf7.c
@@ -170,6 +170,31 @@ static void test_imap_utf7_bad_ascii(void)
 	test_end();
 }
 
+static void test_imap_utf7_raw_octet_after_shift(void)
+{
+	string_t *dest;
+	unsigned int i;
+
+	dest = t_str_new(256);
+
+	test_begin("imap mutf7 raw octet after shift");
+	for (i = 1; i <= 0xff; ++i) {
+		if (i == ' ')
+			i = 0x7f; /* skip the self-coding ASCII range */
+		/* A raw 8-bit or control octet following a completed shift
+		   sequence is invalid mUTF-7. It must be rejected, not silently
+		   emitted (which used to append an embedded NUL and still
+		   return success). */
+		const unsigned char csrc[] = {
+			'&', 'A', 'A', 'E', '-', (unsigned char)i, '\0'
+		};
+		test_assert_idx(!imap_utf7_is_valid((const char *)csrc), i);
+		str_truncate(dest, 0);
+		test_assert_idx(imap_utf7_to_utf8((const char *)csrc, dest) < 0, i);
+	}
+	test_end();
+}
+
 static void test_imap_utf7_unnecessary(void)
 {
 	string_t *dest;
@@ -210,6 +235,7 @@ int main(void)
 		test_imap_utf7_ucs4_cases,
 		test_imap_utf7_non_utf16,
 		test_imap_utf7_bad_ascii,
+		test_imap_utf7_raw_octet_after_shift,
 		test_imap_utf7_unnecessary,
 		NULL
 	};


### PR DESCRIPTION
- [ ] I confirm that this PR does not fix, disclose, demonstrate, or discuss a suspected security vulnerability.
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md) and [SECURITY.md](./SECURITY.md)
- [ ] I have compiled and tested this code

## AI policy

Dovecot allows AI assisted or generated code, but we would like to know if it is such.
Do not include 'Co-Authored-By' header in the commit.

- [ ] This PR includes AI-generated code or text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor or code cleanup

## Description

imap_utf7_to_utf8() is supposed to reject invalid mUTF-7, but a raw 8-bit or control octet that appears outside a shift sequence is emitted silently instead: the non-escaped path in imap_utf7_to_utf8_int() (escape_chars is "") falls into the escape branch, runs str_printfa(dest, "%c%02x", '\0', octet) which appends a NUL byte, and still returns success. That disagrees with imap_utf7_is_valid(), which rejects the same input, so a client mailbox name such as `&AAE-\x80` (SELECT/CREATE/LIST via client_find_namespace_full) slips past the "not valid mUTF-7" check and yields a name containing an embedded NUL. The fix returns -1 in the non-escaped path, matching the sibling mbase64 failure branch just below it; the escaped API and every valid input are unchanged.

## Additional Notes

Added test_imap_utf7_raw_octet_after_shift to test-imap-utf7.c. It sweeps every control/8-bit octet placed after a completed shift and asserts both imap_utf7_is_valid() and imap_utf7_to_utf8() reject it. The case fails on the current tree (the octet is accepted with an embedded NUL) and passes with this change, while the existing valid-input and escaped round-trip cases are unaffected.
