### PR TITLE
Remove 'name' attribute from tokenizer elements

### DIFF
--- a/doc/solr-schema-9.xml
+++ b/doc/solr-schema-9.xml
@@ -6,7 +6,7 @@
   <fieldType name="string" class="solr.StrField" omitNorms="true" sortMissingLast="true"/>
   <fieldType name="text" class="solr.TextField" autoGeneratePhraseQueries="true" positionIncrementGap="100">
     <analyzer type="index">
-      <tokenizer name="standard" class="solr.StandardTokenizerFactory"/>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
       <filter name="icuFolding" />
       <filter name="wordDelimiterGraph" catenateNumbers="1" generateNumberParts="1" splitOnCaseChange="1" generateWordParts="1" splitOnNumerics="1" catenateAll="1" catenateWords="1"/>
       <filter name="flattenGraph"/>
@@ -14,7 +14,7 @@
       <filter name="porterStem"/>
     </analyzer>
     <analyzer type="query">
-      <tokenizer name="standard" class="solr.StandardTokenizerFactory"/>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
       <filter name="icuFolding" />
       <filter name="synonymGraph" expand="true" ignoreCase="true" synonyms="synonyms.txt"/>
       <filter name="flattenGraph" />


### PR DESCRIPTION
both name and class cause a startup error in current solr, it should be only one of those, so only class is retained.

# Pull Request

If this pull request fixes, discloses, demonstrates or discusses a suspected security vulnerability,
**DO NOT submit it publicly**. Follow [SECURITY.md](./SECURITY.MD) and report it privately.

- [X] I confirm that this PR does not fix, disclose, demonstrate, or discuss a suspected security vulnerability.
- [X] I have read [CONTRIBUTING.md](./CONTRIBUTING.md) and [SECURITY.md](./SECURITY.md)
- [X] I have compiled and tested this code'

## AI policy

Dovecot allows AI assisted or generated code, but we would like to know if it is such.
Do not include 'Co-Authored-By' header in the commit.

- [ ] This PR includes AI-generated code or text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor or code cleanup

## Description

Both solr 9.8+ and current 10 versions refuse to load core schema when tokenizer has both name and class properties. Only keeping class here seemed like the right thing to do. After this my dovecot core loads and works withwith solr-10.0.0 on my system.

## Additional Notes

<!-- Anything else reviewers should know -->
