### PR TITLE
OSS-Fuzz: Add new fuzzer targets imap parsing

### DIFF
--- a/src/lib-imap/Makefile.am
+++ b/src/lib-imap/Makefile.am
@@ -109,7 +109,8 @@ test_imap_util_DEPENDENCIES = $(test_deps)
 if USE_FUZZER
 noinst_PROGRAMS += \
 	fuzz-imap-utf7 \
-	fuzz-imap-bodystructure
+	fuzz-imap-bodystructure \
+	fuzz-imap-parser
 
 nodist_EXTRA_fuzz_imap_utf7_SOURCES = force-cxx-linking.cxx
 fuzz_imap_utf7_SOURCES = fuzz-imap-utf7.c
@@ -124,6 +125,13 @@ fuzz_imap_bodystructure_CPPFLAGS = $(FUZZER_CPPFLAGS)
 fuzz_imap_bodystructure_LDFLAGS = $(FUZZER_LDFLAGS)
 fuzz_imap_bodystructure_LDADD = libimap.la ../lib-mail/libmail.la $(test_libs)
 fuzz_imap_bodystructure_DEPENDENCIES = libimap.la $(test_deps) ../lib-mail/libmail.la
+
+nodist_EXTRA_fuzz_imap_parser_SOURCES = force-cxx-linking.cxx
+fuzz_imap_parser_SOURCES = fuzz-imap-parser.c
+fuzz_imap_parser_CPPFLAGS = $(FUZZER_CPPFLAGS)
+fuzz_imap_parser_LDFLAGS = $(FUZZER_LDFLAGS)
+fuzz_imap_parser_LDADD = libimap.la $(test_libs)
+fuzz_imap_parser_DEPENDENCIES = libimap.la $(test_deps)
 
 
 endif

--- a/src/lib-imap/fuzz-imap-parser.c
+++ b/src/lib-imap/fuzz-imap-parser.c
@@ -1,0 +1,28 @@
+/* Copyright (c) Dovecot authors, see top-level COPYING file */
+
+#include "lib.h"
+#include "istream.h"
+#include "fuzzer.h"
+#include "imap-arg.h"
+#include "imap-parser.h"
+
+#define MAX_LINE_SIZE 4096
+
+FUZZ_BEGIN_DATA(const uint8_t *data, size_t size)
+{
+	struct istream *input = i_stream_create_from_data(data, size);
+	struct imap_parser *parser =
+		imap_parser_create(input, NULL, MAX_LINE_SIZE, NULL);
+	const struct imap_arg *args;
+	const char *tag, *name;
+
+	(void)i_stream_read(input);
+
+	if (imap_parser_read_tag(parser, &tag) > 0 &&
+	    imap_parser_read_command_name(parser, &name) > 0)
+		(void)imap_parser_finish_line(parser, 0, 0, &args);
+
+	imap_parser_unref(&parser);
+	i_stream_destroy(&input);
+}
+FUZZ_END


### PR DESCRIPTION
This PR creates a new OSS-Fuzz fuzzer targets imap parsing functionality.