### PR TITLE
lib: xxh64: fix byte ordering bug on big-endian systems

### DIFF
--- a/src/lib/xxh64.c
+++ b/src/lib/xxh64.c
@@ -8,6 +8,8 @@
 #include "lib.h"
 #include "xxh64.h"
 
+#include <endian.h>
+
 #define XXH64_PRIME1  UINT64_C(0x9E3779B185EBCA87)
 #define XXH64_PRIME2  UINT64_C(0xC2B2AE3D27D4EB4F)
 #define XXH64_PRIME3  UINT64_C(0x165667B19E3779F9)
@@ -20,14 +22,14 @@ static inline uint64_t xxh64_read64(const void *p)
 {
 	uint64_t v;
 	memcpy(&v, p, sizeof(v));
-	return v;
+	return le64toh(v);  /* Convert from little-endian to host byte order */
 }
 
 static inline uint32_t xxh64_read32(const void *p)
 {
 	uint32_t v;
 	memcpy(&v, p, sizeof(v));
-	return v;
+	return le32toh(v);  /* Convert from little-endian to host byte order */
 }
 
 static uint64_t ATTR_UNSIGNED_WRAPS xxh64_round(uint64_t acc, uint64_t input)


### PR DESCRIPTION
Convert from little-endian to host byte order where necessary.

Background at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1146449

# Pull Request

- [x] I confirm that this PR does not fix, disclose, demonstrate, or discuss a suspected security vulnerability.
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md) and [SECURITY.md](./SECURITY.md)
- [x] I have compiled and tested this code'

## AI policy

Dovecot allows AI assisted or generated code, but we would like to know if it is such.
Do not include 'Co-Authored-By' header in the commit.

- [ ] This PR includes AI-generated code or text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor or code cleanup

## Description

When dovecot reads multi-byte data from memory and interprets it as unsigned integer data, it fails to properly convert from little endian (as required in the xxh64 spec) to host byte order. This results in different has values depending on the host byte order.

This was identified by the test suite when building Dovecot for Debian/s390x. See [the Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1146449) and [build log](https://buildd.debian.org/status/fetch.php?pkg=dovecot&arch=s390x&ver=1%3A2.4.5%2Bdfsg1-1&stamp=1788223935&raw=0) for more.

