### PR TITLE
doveadm-http: increase max_string_size for json parser

### DIFF
--- a/src/doveadm/client-connection-http.c
+++ b/src/doveadm/client-connection-http.c
@@ -663,10 +663,13 @@ doveadm_http_server_read_request_v1(struct client_request_http *req)
 	struct http_server_request *http_sreq = req->http_request;
 	const char *error;
 	int ret;
+        const struct json_limits limits = {
+		.max_string_size = 1024*1024U,
+        };
 
 	if (req->json_input == NULL) {
 		req->json_input = json_istream_create_array(
-			req->input, NULL, JSON_PARSER_FLAG_NUMBERS_AS_STRING);
+			req->input, &limits, JSON_PARSER_FLAG_NUMBERS_AS_STRING);
 	}
 
 	if (req->json_output == NULL) {


### PR DESCRIPTION
as json can contain whole sieve scripts as a string, increase the (default) max allowed string size for sieve scripts

# Pull Request

If this pull request fixes, discloses, demonstrates or discusses a suspected security vulnerability,
**DO NOT submit it publicly**. Follow [SECURITY.md](./SECURITY.MD) and report it privately.

- [x] I confirm that this PR does not fix, disclose, demonstrate, or discuss a suspected security vulnerability.
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md) and [SECURITY.md](./SECURITY.md)
- [x] I have compiled and tested this code

## AI policy

Dovecot allows AI assisted or generated code, but we would like to know if it is such.
Do not include 'Co-Authored-By' header in the commit.

- [ ] This PR includes AI-generated code or text.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor or code cleanup

## Description

Submitting large sieve scripts via `sievePut` REST API calls fails. The sieve plugin allows up to 1M size of sieve script (by default), see https://doc.dovecot.org/2.4.5/core/plugins/sieve.html#sieve_max_script_size. But the JSON parser only allows 32K for string parameters. This patch increases this limit to 1M (similar to sieve) for the JSON parser for doveadm HTTP connections. 

## Additional Notes

Technically it might be possible to read out the `sieve_max_script_size` setting here and use this value (if found). But as the setting is already *advanced* and looking up a plugin setting in the core code seems not a good idea (and probably complicated too), I decided for this simple solution. It would also possible to provide a settings variable to allow users to set the variable to higher values. Let me know, if I should improve the PR to provide such a setting.