### PR TITLE
Fix time arithmetic on 32-bit systems

### DIFF
--- a/m4/gmtime_max.m4
+++ b/m4/gmtime_max.m4
@@ -21,12 +21,10 @@ AC_DEFUN([DOVECOT_GMTIME_MAX], [
              Let's just do the same as Cyrus folks and limit it to 40 bits. */
           bits = 40;
         }
-        #ifdef TIME_T_SIGNED
         if (bits == 32) {
           /* Signed 32-bit time_t is essentially the same as unsigned 31-bit time_t */
           bits = 31;
         }
-        #endif
     
         f = fopen("conftest.temp", "w");
         if (f == NULL) {


### PR DESCRIPTION
## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor or code cleanup

## Description

Commit 7cedd93c required that `time_t` be signed, and commit 00a26d61 dropped the `TIME_T_SIGNED` define.

However, `m4/gmtime_max.m4` still used `TIME_T_SIGNED`, and without that we get `TIME_T_MAX_BITS` of 32 on 32-bit systems rather than 31. This breaks an assumption in `time_max_safe_value()` in `src/lib/time-util.c`, which results in the `time_add_secs()` and `time_sub_secs()` functions malfunctioning.
